### PR TITLE
adds new editable-text component.

### DIFF
--- a/packages/frontend/app/components/competency-title-editor.gjs
+++ b/packages/frontend/app/components/competency-title-editor.gjs
@@ -11,6 +11,7 @@ import { on } from '@ember/modifier';
 import pick from 'ilios-common/helpers/pick';
 import set from 'ember-set-helper/helpers/set';
 import YupValidationMessage from 'ilios-common/components/yup-validation-message';
+import focus from 'ilios-common/modifiers/focus';
 
 export default class CompetencyTitleEditorComponent extends Component {
   @tracked title;
@@ -56,6 +57,7 @@ export default class CompetencyTitleEditorComponent extends Component {
             {{on "input" (pick "target.value" (set this "title"))}}
             {{this.validations.attach "title"}}
             {{keyboard}}
+            {{focus}}
           />
         </EditableField>
         <YupValidationMessage

--- a/packages/frontend/app/components/competency-title-editor.gjs
+++ b/packages/frontend/app/components/competency-title-editor.gjs
@@ -45,10 +45,8 @@ export default class CompetencyTitleEditorComponent extends Component {
           @value={{this.title}}
           @save={{perform this.save}}
           @close={{this.revert}}
-          @saveOnEnter={{true}}
           data-test-title
-          @closeOnEscape={{true}}
-          as |isSaving|
+          as |keyboard isSaving|
         >
           <input
             type="text"
@@ -57,6 +55,7 @@ export default class CompetencyTitleEditorComponent extends Component {
             aria-label={{t "general.title"}}
             {{on "input" (pick "target.value" (set this "title"))}}
             {{this.validations.attach "title"}}
+            {{keyboard}}
           />
         </EditableField>
         <YupValidationMessage

--- a/packages/frontend/app/components/curriculum-inventory/report-header.gjs
+++ b/packages/frontend/app/components/curriculum-inventory/report-header.gjs
@@ -55,9 +55,7 @@ export default class CurriculumInventoryReportHeaderComponent extends Component 
             @value={{if this.name this.name (t "general.clickToEdit")}}
             @save={{perform this.saveName}}
             @close={{this.revertNameChanges}}
-            @saveOnEnter={{true}}
-            @closeOnEscape={{true}}
-            as |isSaving|
+            as |keyboard isSaving|
           >
             <input
               aria-label={{t "general.title"}}
@@ -66,6 +64,7 @@ export default class CurriculumInventoryReportHeaderComponent extends Component 
               disabled={{isSaving}}
               {{on "input" (pick "target.value" (set this "name"))}}
               {{this.validations.attach "name"}}
+              {{keyboard}}
             />
             <YupValidationMessage
               @description={{t "general.name"}}

--- a/packages/frontend/app/components/curriculum-inventory/report-header.gjs
+++ b/packages/frontend/app/components/curriculum-inventory/report-header.gjs
@@ -13,6 +13,7 @@ import set from 'ember-set-helper/helpers/set';
 import YupValidationMessage from 'ilios-common/components/yup-validation-message';
 import FaIcon from 'ilios-common/components/fa-icon';
 import not from 'ember-truth-helpers/helpers/not';
+import focus from 'ilios-common/modifiers/focus';
 
 export default class CurriculumInventoryReportHeaderComponent extends Component {
   @tracked name;
@@ -65,6 +66,7 @@ export default class CurriculumInventoryReportHeaderComponent extends Component 
               {{on "input" (pick "target.value" (set this "name"))}}
               {{this.validations.attach "name"}}
               {{keyboard}}
+              {{focus}}
             />
             <YupValidationMessage
               @description={{t "general.name"}}

--- a/packages/frontend/app/components/curriculum-inventory/report-overview.gjs
+++ b/packages/frontend/app/components/curriculum-inventory/report-overview.gjs
@@ -378,8 +378,7 @@ export default class CurriculumInventoryReportOverviewComponent extends Componen
                   @save={{perform this.changeDescription}}
                   @close={{this.revertDescriptionChanges}}
                   @clickPrompt={{if this.description this.description (t "general.clickToEdit")}}
-                  @closeOnEscape={{true}}
-                  as |isSaving|
+                  as |keyboard isSaving|
                 >
                   <textarea
                     id="description-{{templateId}}"
@@ -388,6 +387,7 @@ export default class CurriculumInventoryReportOverviewComponent extends Componen
                     {{on "input" (pick "target.value" (set this "description"))}}
                     {{this.validations.attach "description"}}
                     placeholder={{t "general.reportDescriptionPlaceholder"}}
+                    {{keyboard saveOnEnter=false}}
                   >
                     {{this.description}}
                   </textarea>

--- a/packages/frontend/app/components/curriculum-inventory/report-overview.gjs
+++ b/packages/frontend/app/components/curriculum-inventory/report-overview.gjs
@@ -22,6 +22,7 @@ import and from 'ember-truth-helpers/helpers/and';
 import not from 'ember-truth-helpers/helpers/not';
 import pick from 'ilios-common/helpers/pick';
 import eq from 'ember-truth-helpers/helpers/eq';
+import focus from 'ilios-common/modifiers/focus';
 
 export default class CurriculumInventoryReportOverviewComponent extends Component {
   @service currentUser;
@@ -284,6 +285,7 @@ export default class CurriculumInventoryReportOverviewComponent extends Componen
                   <DatePicker
                     @value={{this.startDate}}
                     @onChange={{set this "startDate"}}
+                    @autofocus={{true}}
                     {{this.validations.attach "startDate"}}
                     data-test-start-date-picker
                   />
@@ -312,6 +314,7 @@ export default class CurriculumInventoryReportOverviewComponent extends Componen
                   <DatePicker
                     @value={{this.endDate}}
                     @onChange={{set this "endDate"}}
+                    @autofocus={{true}}
                     {{this.validations.attach "endDate"}}
                     data-test-end-date-picker
                   />
@@ -340,6 +343,7 @@ export default class CurriculumInventoryReportOverviewComponent extends Componen
                   <select
                     id="year-{{templateId}}"
                     {{on "change" (pick "target.value" (set this "year"))}}
+                    {{focus}}
                   >
                     {{#each this.yearOptions as |obj|}}
                       <option
@@ -388,6 +392,7 @@ export default class CurriculumInventoryReportOverviewComponent extends Componen
                     {{this.validations.attach "description"}}
                     placeholder={{t "general.reportDescriptionPlaceholder"}}
                     {{keyboard saveOnEnter=false}}
+                    {{focus}}
                   >
                     {{this.description}}
                   </textarea>

--- a/packages/frontend/app/components/curriculum-inventory/sequence-block-header.gjs
+++ b/packages/frontend/app/components/curriculum-inventory/sequence-block-header.gjs
@@ -55,9 +55,7 @@ export default class CurriculumInventorySequenceBlockHeaderComponent extends Com
             @value={{this.title}}
             @save={{perform this.changeTitle}}
             @close={{this.revertTitleChanges}}
-            @saveOnEnter={{true}}
-            @closeOnEscape={{true}}
-            as |isSaving|
+            as |keyboard isSaving|
           >
             <input
               aria-label={{t "general.title"}}
@@ -66,6 +64,7 @@ export default class CurriculumInventorySequenceBlockHeaderComponent extends Com
               disabled={{isSaving}}
               {{on "input" (pick "target.value" (set this "titleBuffer"))}}
               {{this.validations.attach "title"}}
+              {{keyboard}}
             />
             <YupValidationMessage
               @description={{t "general.title"}}

--- a/packages/frontend/app/components/curriculum-inventory/sequence-block-header.gjs
+++ b/packages/frontend/app/components/curriculum-inventory/sequence-block-header.gjs
@@ -13,6 +13,7 @@ import pick from 'ilios-common/helpers/pick';
 import set from 'ember-set-helper/helpers/set';
 import YupValidationMessage from 'ilios-common/components/yup-validation-message';
 import FaIcon from 'ilios-common/components/fa-icon';
+import focus from 'ilios-common/modifiers/focus';
 
 export default class CurriculumInventorySequenceBlockHeaderComponent extends Component {
   @service store;
@@ -65,6 +66,7 @@ export default class CurriculumInventorySequenceBlockHeaderComponent extends Com
               {{on "input" (pick "target.value" (set this "titleBuffer"))}}
               {{this.validations.attach "title"}}
               {{keyboard}}
+              {{focus}}
             />
             <YupValidationMessage
               @description={{t "general.title"}}

--- a/packages/frontend/app/components/curriculum-inventory/sequence-block-overview.gjs
+++ b/packages/frontend/app/components/curriculum-inventory/sequence-block-overview.gjs
@@ -745,14 +745,14 @@ export default class CurriculumInventorySequenceBlockOverviewComponent extends C
                   }}
                   @save={{perform this.saveDescription}}
                   @close={{this.revertDescriptionChanges}}
-                  @closeOnEscape={{true}}
-                  as |isSaving|
+                  as |keyboard isSaving|
                 >
                   <textarea
                     id="description-{{templateId}}"
                     value={{this.description}}
                     oninput={{this.changeDescription}}
                     disabled={{isSaving}}
+                    {{keyboard saveOnEnter=false}}
                   >
                     {{this.description}}
                   </textarea>

--- a/packages/frontend/app/components/curriculum-inventory/sequence-block-overview.gjs
+++ b/packages/frontend/app/components/curriculum-inventory/sequence-block-overview.gjs
@@ -30,6 +30,7 @@ import and from 'ember-truth-helpers/helpers/and';
 import not from 'ember-truth-helpers/helpers/not';
 import SequenceBlockSessionManager from 'frontend/components/curriculum-inventory/sequence-block-session-manager';
 import SequenceBlockSessionList from 'frontend/components/curriculum-inventory/sequence-block-session-list';
+import focus from 'ilios-common/modifiers/focus';
 
 export default class CurriculumInventorySequenceBlockOverviewComponent extends Component {
   @service intl;
@@ -672,7 +673,7 @@ export default class CurriculumInventorySequenceBlockOverviewComponent extends C
                     @close={{this.revertCourseChanges}}
                     @clickPrompt={{t "general.selectCourse"}}
                   >
-                    <select id="course-{{templateId}}" {{on "change" this.updateCourse}}>
+                    <select id="course-{{templateId}}" {{on "change" this.updateCourse}} {{focus}}>
                       <option value selected={{isEmpty this.course}}>{{t
                           "general.selectCourse"
                         }}</option>
@@ -753,6 +754,7 @@ export default class CurriculumInventorySequenceBlockOverviewComponent extends C
                     oninput={{this.changeDescription}}
                     disabled={{isSaving}}
                     {{keyboard saveOnEnter=false}}
+                    {{focus}}
                   >
                     {{this.description}}
                   </textarea>
@@ -772,6 +774,7 @@ export default class CurriculumInventorySequenceBlockOverviewComponent extends C
                   <select
                     id="required-{{templateId}}"
                     {{on "change" (pick "target.value" this.setRequired)}}
+                    {{focus}}
                   >
                     <option value="1" selected={{eq this.required "1"}}>{{t
                         "general.required"
@@ -987,6 +990,7 @@ export default class CurriculumInventorySequenceBlockOverviewComponent extends C
                   <select
                     id="child-sequence-order-{{templateId}}"
                     {{on "change" (pick "target.value" (set this "childSequenceOrder"))}}
+                    {{focus}}
                   >
                     <option value="1" selected={{eq this.childSequenceOrder "1"}}>{{t
                         "general.ordered"
@@ -1016,6 +1020,7 @@ export default class CurriculumInventorySequenceBlockOverviewComponent extends C
                       <select
                         id="order-in-sequence-{{templateId}}"
                         {{on "change" this.updateOrderInSequence}}
+                        {{focus}}
                       >
                         {{#each this.orderInSequenceOptions as |val|}}
                           <option
@@ -1047,6 +1052,7 @@ export default class CurriculumInventorySequenceBlockOverviewComponent extends C
                     id="starting-academic-level-{{templateId}}"
                     {{on "change" this.setStartLevel}}
                     {{this.validations.attach "startLevel"}}
+                    {{focus}}
                   >
                     {{#each (sortBy "level" this.academicLevels) as |obj|}}
                       <option
@@ -1077,6 +1083,7 @@ export default class CurriculumInventorySequenceBlockOverviewComponent extends C
                     id="ending-academic-level-{{templateId}}"
                     {{on "change" this.setEndLevel}}
                     {{this.validations.attach "endLevel"}}
+                    {{focus}}
                   >
                     {{#each (sortBy "level" this.academicLevels) as |obj|}}
                       <option

--- a/packages/frontend/app/components/instructor-group/header.gjs
+++ b/packages/frontend/app/components/instructor-group/header.gjs
@@ -14,6 +14,7 @@ import set from 'ember-set-helper/helpers/set';
 import YupValidationMessage from 'ilios-common/components/yup-validation-message';
 import { LinkTo } from '@ember/routing';
 import { hash } from '@ember/helper';
+import focus from 'ilios-common/modifiers/focus';
 
 export default class InstructorGroupHeaderComponent extends Component {
   @service store;
@@ -65,6 +66,7 @@ export default class InstructorGroupHeaderComponent extends Component {
                 {{on "input" (pick "target.value" (set this "title"))}}
                 {{this.validations.attach "title"}}
                 {{keyboard}}
+                {{focus}}
               />
               <YupValidationMessage
                 @description={{t "general.title"}}

--- a/packages/frontend/app/components/instructor-group/header.gjs
+++ b/packages/frontend/app/components/instructor-group/header.gjs
@@ -55,9 +55,7 @@ export default class InstructorGroupHeaderComponent extends Component {
               @value={{this.title}}
               @save={{perform this.changeTitle}}
               @close={{this.revertTitleChanges}}
-              @saveOnEnter={{true}}
-              @closeOnEscape={{true}}
-              as |isSaving|
+              as |keyboard isSaving|
             >
               <input
                 aria-label={{t "general.instructorGroupTitle"}}
@@ -66,6 +64,7 @@ export default class InstructorGroupHeaderComponent extends Component {
                 disabled={{isSaving}}
                 {{on "input" (pick "target.value" (set this "title"))}}
                 {{this.validations.attach "title"}}
+                {{keyboard}}
               />
               <YupValidationMessage
                 @description={{t "general.title"}}

--- a/packages/frontend/app/components/learner-group/header.gjs
+++ b/packages/frontend/app/components/learner-group/header.gjs
@@ -90,9 +90,7 @@ export default class LearnerGroupHeaderComponent extends Component {
               @value={{if @learnerGroup.title @learnerGroup.title (t "general.clickToEdit")}}
               @save={{perform this.changeTitle}}
               @close={{this.revertTitleChanges}}
-              @saveOnEnter={{true}}
-              @closeOnEscape={{true}}
-              as |isSaving|
+              as |keyboard isSaving|
             >
               <input
                 aria-label={{t "general.learnerGroupTitle"}}
@@ -101,6 +99,7 @@ export default class LearnerGroupHeaderComponent extends Component {
                 disabled={{isSaving}}
                 {{on "input" (pick "target.value" (set this "titleBuffer"))}}
                 {{this.validations.attach "title"}}
+                {{keyboard}}
               />
               <YupValidationMessage
                 @description={{t "general.title"}}

--- a/packages/frontend/app/components/learner-group/header.gjs
+++ b/packages/frontend/app/components/learner-group/header.gjs
@@ -15,6 +15,7 @@ import reverse from 'ilios-common/helpers/reverse';
 import YupValidations from 'ilios-common/classes/yup-validations';
 import YupValidationMessage from 'ilios-common/components/yup-validation-message';
 import { string } from 'yup';
+import focus from 'ilios-common/modifiers/focus';
 
 export default class LearnerGroupHeaderComponent extends Component {
   @tracked titleBuffer;
@@ -100,6 +101,7 @@ export default class LearnerGroupHeaderComponent extends Component {
                 {{on "input" (pick "target.value" (set this "titleBuffer"))}}
                 {{this.validations.attach "title"}}
                 {{keyboard}}
+                {{focus}}
               />
               <YupValidationMessage
                 @description={{t "general.title"}}

--- a/packages/frontend/app/components/learner-group/root.gjs
+++ b/packages/frontend/app/components/learner-group/root.gjs
@@ -521,9 +521,7 @@ export default class LearnerGroupRootComponent extends Component {
                   }}
                   @save={{perform this.changeLocation}}
                   @close={{this.revertLocationChanges}}
-                  @saveOnEnter={{true}}
-                  @closeOnEscape={{true}}
-                  as |isSaving|
+                  as |keyboard isSaving|
                 >
                   <input
                     id="location-{{templateId}}"
@@ -531,6 +529,7 @@ export default class LearnerGroupRootComponent extends Component {
                     value={{this.location}}
                     disabled={{isSaving}}
                     {{on "input" (pick "target.value" (set this "locationBuffer"))}}
+                    {{keyboard}}
                   />
                 </EditableField>
               {{else if @learnerGroup.location}}
@@ -550,9 +549,7 @@ export default class LearnerGroupRootComponent extends Component {
                   @value={{if @learnerGroup.url @learnerGroup.url (t "general.clickToEdit")}}
                   @save={{perform this.saveUrlChanges}}
                   @close={{this.revertUrlChanges}}
-                  @saveOnEnter={{true}}
-                  @closeOnEscape={{true}}
-                  as |isSaving|
+                  as |keyboard isSaving|
                 >
                   {{! template-lint-disable no-bare-strings}}
                   <input
@@ -565,6 +562,7 @@ export default class LearnerGroupRootComponent extends Component {
                     {{on "input" (pick "target.value" this.changeUrl)}}
                     {{on "focus" this.selectAllText}}
                     {{this.validations.attach "bestUrl"}}
+                    {{keyboard}}
                   />
                   <YupValidationMessage
                     @description={{t "general.defaultVirtualLearningLink"}}

--- a/packages/frontend/app/components/learner-group/root.gjs
+++ b/packages/frontend/app/components/learner-group/root.gjs
@@ -45,6 +45,8 @@ import YupValidationMessage from 'ilios-common/components/yup-validation-message
 import { string } from 'yup';
 import { pageTitle } from 'ember-page-title';
 import reverse from 'ilios-common/helpers/reverse';
+import focus from 'ilios-common/modifiers/focus';
+
 const DEFAULT_URL_VALUE = 'https://';
 
 export default class LearnerGroupRootComponent extends Component {
@@ -530,6 +532,7 @@ export default class LearnerGroupRootComponent extends Component {
                     disabled={{isSaving}}
                     {{on "input" (pick "target.value" (set this "locationBuffer"))}}
                     {{keyboard}}
+                    {{focus}}
                   />
                 </EditableField>
               {{else if @learnerGroup.location}}
@@ -563,6 +566,7 @@ export default class LearnerGroupRootComponent extends Component {
                     {{on "focus" this.selectAllText}}
                     {{this.validations.attach "bestUrl"}}
                     {{keyboard}}
+                    {{focus}}
                   />
                   <YupValidationMessage
                     @description={{t "general.defaultVirtualLearningLink"}}

--- a/packages/frontend/app/components/program-year/objective-list-item.gjs
+++ b/packages/frontend/app/components/program-year/objective-list-item.gjs
@@ -183,10 +183,6 @@ export default class ProgramYearObjectiveListItemComponent extends Component {
   });
 
   @action
-  expandAllFadeText(isExpanded) {
-    this.fadeTextExpanded = isExpanded;
-  }
-  @action
   revertDescriptionChanges() {
     this.description = this.args.programYearObjective.title;
     this.validations.removeErrorDisplayFor('descriptionWithoutMarkup');
@@ -253,37 +249,42 @@ export default class ProgramYearObjectiveListItemComponent extends Component {
         {{/if}}
       </button>
       <div class="description grid-item" data-test-description>
-        {{#if (and @editable (not this.isManaging) (not this.showRemoveConfirmation))}}
-          <EditableField
-            @value={{this.description}}
-            @renderHtml={{true}}
-            @save={{perform this.saveDescriptionChanges}}
-            @close={{this.revertDescriptionChanges}}
-          >
-            <:default>
-              <HtmlEditor
-                @content={{this.description}}
-                @update={{this.changeDescription}}
-                @autofocus={{true}}
-              />
-              <YupValidationMessage
-                @description={{t "general.description"}}
-                @validationErrors={{this.validations.errors.descriptionWithoutMarkup}}
-                data-test-description-validation-error-message
-              />
-            </:default>
-            <:value>
-              <FadeText
-                @expanded={{this.fadeTextExpanded}}
-                @onExpandAll={{this.expandAllFadeText}}
-                @text={{this.description}}
-              />
-            </:value>
-          </EditableField>
-        {{else}}
-          {{! template-lint-disable no-triple-curlies }}
-          {{{@programYearObjective.title}}}
-        {{/if}}
+        <FadeText
+          @forceExpanded={{this.fadeTextExpanded}}
+          @setExpanded={{set this "fadeTextExpanded"}}
+          @text={{this.description}}
+          as |ft|
+        >
+          {{#if (and @editable (not this.isManaging) (not this.showRemoveConfirmation))}}
+            <EditableField
+              @value={{this.description}}
+              @save={{perform this.saveDescriptionChanges}}
+              @close={{this.revertDescriptionChanges}}
+            >
+              <:default>
+                <HtmlEditor
+                  @content={{this.description}}
+                  @update={{this.changeDescription}}
+                  @autofocus={{true}}
+                />
+                <YupValidationMessage
+                  @description={{t "general.description"}}
+                  @validationErrors={{this.validations.errors.descriptionWithoutMarkup}}
+                  data-test-description-validation-error-message
+                />
+              </:default>
+              <:value>
+                {{ft.text}}
+              </:value>
+              <:postValue>
+                {{ft.controls}}
+              </:postValue>
+            </EditableField>
+          {{else}}
+            {{ft.text}}
+            {{ft.controls}}
+          {{/if}}
+        </FadeText>
       </div>
       <ObjectiveListItemCompetency
         @objective={{@programYearObjective}}

--- a/packages/frontend/app/components/program-year/objective-list-item.gjs
+++ b/packages/frontend/app/components/program-year/objective-list-item.gjs
@@ -26,6 +26,7 @@ import YupValidations from 'ilios-common/classes/yup-validations';
 import YupValidationMessage from 'ilios-common/components/yup-validation-message';
 import { string } from 'yup';
 import striptags from 'striptags';
+import FadeText from 'ilios-common/components/fade-text';
 
 export default class ProgramYearObjectiveListItemComponent extends Component {
   @service store;
@@ -258,19 +259,26 @@ export default class ProgramYearObjectiveListItemComponent extends Component {
             @renderHtml={{true}}
             @save={{perform this.saveDescriptionChanges}}
             @close={{this.revertDescriptionChanges}}
-            @fadeTextExpanded={{this.fadeTextExpanded}}
-            @onExpandAllFadeText={{this.expandAllFadeText}}
           >
-            <HtmlEditor
-              @content={{this.description}}
-              @update={{this.changeDescription}}
-              @autofocus={{true}}
-            />
-            <YupValidationMessage
-              @description={{t "general.description"}}
-              @validationErrors={{this.validations.errors.descriptionWithoutMarkup}}
-              data-test-description-validation-error-message
-            />
+            <:default>
+              <HtmlEditor
+                @content={{this.description}}
+                @update={{this.changeDescription}}
+                @autofocus={{true}}
+              />
+              <YupValidationMessage
+                @description={{t "general.description"}}
+                @validationErrors={{this.validations.errors.descriptionWithoutMarkup}}
+                data-test-description-validation-error-message
+              />
+            </:default>
+            <:value>
+              <FadeText
+                @expanded={{this.fadeTextExpanded}}
+                @onExpandAll={{this.expandAllFadeText}}
+                @text={{this.description}}
+              />
+            </:value>
           </EditableField>
         {{else}}
           {{! template-lint-disable no-triple-curlies }}

--- a/packages/frontend/app/components/program-year/objective-list-item.gjs
+++ b/packages/frontend/app/components/program-year/objective-list-item.gjs
@@ -281,7 +281,7 @@ export default class ProgramYearObjectiveListItemComponent extends Component {
               </:postValue>
             </EditableField>
           {{else}}
-            {{ft.text}}
+            {{ft.text preserveLinks=true}}
             {{ft.controls}}
           {{/if}}
         </FadeText>

--- a/packages/frontend/app/components/program/header.gjs
+++ b/packages/frontend/app/components/program/header.gjs
@@ -10,6 +10,7 @@ import t from 'ember-intl/helpers/t';
 import { on } from '@ember/modifier';
 import pick from 'ilios-common/helpers/pick';
 import YupValidationMessage from 'ilios-common/components/yup-validation-message';
+import focus from 'ilios-common/modifiers/focus';
 
 export default class ProgramHeaderComponent extends Component {
   @tracked title;
@@ -55,6 +56,7 @@ export default class ProgramHeaderComponent extends Component {
               {{this.validations.attach "title"}}
               disabled={{isSaving}}
               {{keyboard}}
+              {{focus}}
             />
             <YupValidationMessage
               @description={{t "general.title"}}

--- a/packages/frontend/app/components/program/header.gjs
+++ b/packages/frontend/app/components/program/header.gjs
@@ -44,10 +44,8 @@ export default class ProgramHeaderComponent extends Component {
             @value={{this.title}}
             @save={{perform this.changeTitle}}
             @close={{set this "title" @program.title}}
-            @saveOnEnter={{true}}
             @clickPrompt={{t "general.clickToEdit"}}
-            @closeOnEscape={{true}}
-            as |isSaving|
+            as |keyboard isSaving|
           >
             <input
               type="text"
@@ -56,6 +54,7 @@ export default class ProgramHeaderComponent extends Component {
               {{on "input" (pick "target.value" (set this "title"))}}
               {{this.validations.attach "title"}}
               disabled={{isSaving}}
+              {{keyboard}}
             />
             <YupValidationMessage
               @description={{t "general.title"}}

--- a/packages/frontend/app/components/program/overview.gjs
+++ b/packages/frontend/app/components/program/overview.gjs
@@ -14,6 +14,7 @@ import { on } from '@ember/modifier';
 import pick from 'ilios-common/helpers/pick';
 import YupValidationMessage from 'ilios-common/components/yup-validation-message';
 import eq from 'ember-truth-helpers/helpers/eq';
+import focus from 'ilios-common/modifiers/focus';
 
 export default class ProgramOverviewComponent extends Component {
   id = guidFor(this);
@@ -83,6 +84,7 @@ export default class ProgramOverviewComponent extends Component {
                   {{this.validations.attach "shortTitle"}}
                   disabled={{isSaving}}
                   {{keyboard}}
+                  {{focus}}
                 />
               </EditableField>
               <YupValidationMessage
@@ -105,7 +107,7 @@ export default class ProgramOverviewComponent extends Component {
                 @save={{perform this.changeDuration}}
                 @close={{set this "duration" @program.duration}}
               >
-                <select id={{concat this.id "duration"}} {{on "change" this.setDuration}}>
+                <select id={{concat this.id "duration"}} {{on "change" this.setDuration}} {{focus}}>
                   {{#each (array 1 2 3 4 5 6 7 8 9 10) as |val|}}
                     <option value={{val}} selected={{eq val this.duration}}>{{val}}</option>
                   {{/each}}

--- a/packages/frontend/app/components/program/overview.gjs
+++ b/packages/frontend/app/components/program/overview.gjs
@@ -72,10 +72,8 @@ export default class ProgramOverviewComponent extends Component {
                 @value={{this.shortTitle}}
                 @save={{perform this.changeShortTitle}}
                 @close={{set this "duration" @program.duration}}
-                @saveOnEnter={{true}}
                 @clickPrompt={{t "general.clickToEdit"}}
-                @closeOnEscape={{true}}
-                as |isSaving|
+                as |keyboard isSaving|
               >
                 <input
                   id={{concat this.id "short-title"}}
@@ -84,6 +82,7 @@ export default class ProgramOverviewComponent extends Component {
                   {{on "input" (pick "target.value" (set this "shortTitle"))}}
                   {{this.validations.attach "shortTitle"}}
                   disabled={{isSaving}}
+                  {{keyboard}}
                 />
               </EditableField>
               <YupValidationMessage

--- a/packages/frontend/app/components/reports/subject-header.gjs
+++ b/packages/frontend/app/components/reports/subject-header.gjs
@@ -19,6 +19,7 @@ import SubjectCopy from 'frontend/components/reports/subject-copy';
 import SubjectDownload from 'frontend/components/reports/subject-download';
 import SubjectYearFilter from 'frontend/components/reports/subject-year-filter';
 import SubjectDescription from 'frontend/components/reports/subject-description';
+import focus from 'ilios-common/modifiers/focus';
 
 export default class ReportsSubjectHeader extends Component {
   @service router;
@@ -90,6 +91,7 @@ export default class ReportsSubjectHeader extends Component {
               {{on "input" (pick "target.value" (set this "title"))}}
               {{this.validations.attach "title"}}
               {{keyboard}}
+              {{focus}}
             />
             <YupValidationMessage
               @description={{t "general.title"}}

--- a/packages/frontend/app/components/reports/subject-header.gjs
+++ b/packages/frontend/app/components/reports/subject-header.gjs
@@ -79,10 +79,8 @@ export default class ReportsSubjectHeader extends Component {
             @value={{this.reportTitle}}
             @save={{perform this.changeTitle}}
             @close={{this.revertTitleChanges}}
-            @saveOnEnter={{true}}
             @showIcon={{false}}
-            @closeOnEscape={{true}}
-            as |isSaving|
+            as |keyboard isSaving|
           >
             <input
               aria-label={{t "general.reportTitle"}}
@@ -92,6 +90,7 @@ export default class ReportsSubjectHeader extends Component {
               disabled={{isSaving}}
               {{on "input" (pick "target.value" (set this "title"))}}
               {{this.validations.attach "title"}}
+              {{keyboard}}
             />
             <YupValidationMessage
               @description={{t "general.title"}}

--- a/packages/frontend/app/components/reports/subject-header.gjs
+++ b/packages/frontend/app/components/reports/subject-header.gjs
@@ -79,7 +79,6 @@ export default class ReportsSubjectHeader extends Component {
             @value={{this.reportTitle}}
             @save={{perform this.changeTitle}}
             @close={{this.revertTitleChanges}}
-            @showIcon={{false}}
             as |keyboard isSaving|
           >
             <input

--- a/packages/frontend/app/components/school-manager.gjs
+++ b/packages/frontend/app/components/school-manager.gjs
@@ -133,9 +133,7 @@ export default class SchoolManagerComponent extends Component {
               @value={{this.title}}
               @save={{perform this.changeTitle}}
               @close={{this.revertTitleChanges}}
-              @saveOnEnter={{true}}
-              @closeOnEscape={{true}}
-              as |isSaving|
+              as |keyboard isSaving|
             >
               <input
                 aria-label={{t "general.title"}}
@@ -144,6 +142,7 @@ export default class SchoolManagerComponent extends Component {
                 disabled={{isSaving}}
                 {{on "input" (pick "target.value" (set this "title"))}}
                 {{this.validations.attach "title"}}
+                {{keyboard}}
               />
               <YupValidationMessage
                 @description={{t "general.title"}}

--- a/packages/frontend/app/components/school-manager.gjs
+++ b/packages/frontend/app/components/school-manager.gjs
@@ -34,6 +34,7 @@ import EmailsEditor from 'frontend/components/school/emails-editor';
 import Emails from 'frontend/components/school/emails';
 import SchoolInstitutionalInformationManager from 'frontend/components/school-institutional-information-manager';
 import SchoolInstitutionalInformationDetails from 'frontend/components/school-institutional-information-details';
+import focus from 'ilios-common/modifiers/focus';
 
 export default class SchoolManagerComponent extends Component {
   @service flashMessages;
@@ -143,6 +144,7 @@ export default class SchoolManagerComponent extends Component {
                 {{on "input" (pick "target.value" (set this "title"))}}
                 {{this.validations.attach "title"}}
                 {{keyboard}}
+                {{focus}}
               />
               <YupValidationMessage
                 @description={{t "general.title"}}

--- a/packages/frontend/app/components/school-vocabulary-manager.gjs
+++ b/packages/frontend/app/components/school-vocabulary-manager.gjs
@@ -17,6 +17,7 @@ import SchoolVocabularyNewTerm from 'frontend/components/school-vocabulary-new-t
 import YupValidationMessage from 'ilios-common/components/yup-validation-message';
 import YupValidations from 'ilios-common/classes/yup-validations';
 import { string } from 'yup';
+import focus from 'ilios-common/modifiers/focus';
 
 export default class SchoolVocabularyManagerComponent extends Component {
   @service store;
@@ -139,6 +140,7 @@ export default class SchoolVocabularyManagerComponent extends Component {
                 {{on "input" (pick "target.value" (set this "titleBuffer"))}}
                 {{this.validations.attach "title"}}
                 {{keyboard}}
+                {{focus}}
               />
               <YupValidationMessage
                 @description={{t "general.title"}}

--- a/packages/frontend/app/components/school-vocabulary-manager.gjs
+++ b/packages/frontend/app/components/school-vocabulary-manager.gjs
@@ -129,9 +129,7 @@ export default class SchoolVocabularyManagerComponent extends Component {
               @value={{if this.title this.title (t "general.clickToEdit")}}
               @save={{perform this.changeTitle}}
               @close={{this.revertTitleChanges}}
-              @saveOnEnter={{true}}
-              @closeOnEscape={{true}}
-              as |isSaving|
+              as |keyboard isSaving|
             >
               <input
                 id="title-{{templateId}}"
@@ -140,6 +138,7 @@ export default class SchoolVocabularyManagerComponent extends Component {
                 disabled={{isSaving}}
                 {{on "input" (pick "target.value" (set this "titleBuffer"))}}
                 {{this.validations.attach "title"}}
+                {{keyboard}}
               />
               <YupValidationMessage
                 @description={{t "general.title"}}

--- a/packages/frontend/app/components/school-vocabulary-term-manager.gjs
+++ b/packages/frontend/app/components/school-vocabulary-term-manager.gjs
@@ -216,9 +216,7 @@ export default class SchoolVocabularyTermManagerComponent extends Component {
                     @value={{if this.title this.title (t "general.clickToEdit")}}
                     @save={{perform this.changeTitle}}
                     @close={{this.revertTitleChanges}}
-                    @saveOnEnter={{true}}
-                    @closeOnEscape={{true}}
-                    as |isSaving|
+                    as |keyboard isSaving|
                   >
                     <input
                       id="title-{{templateId}}"
@@ -227,6 +225,7 @@ export default class SchoolVocabularyTermManagerComponent extends Component {
                       disabled={{isSaving}}
                       {{on "input" (pick "target.value" (set this "titleBuffer"))}}
                       {{this.validations.attach "title"}}
+                      {{keyboard}}
                     />
                     <YupValidationMessage
                       @description={{t "general.title"}}
@@ -277,14 +276,14 @@ export default class SchoolVocabularyTermManagerComponent extends Component {
                     }}
                     @save={{perform this.changeDescription}}
                     @close={{this.revertDescriptionChanges}}
-                    @closeOnEscape={{true}}
-                    as |isSaving|
+                    as |keyboard isSaving|
                   >
                     <textarea
                       id="description-{{templateId}}"
                       value={{this.description}}
                       {{on "input" (pick "target.value" (set this "descriptionBuffer"))}}
                       disabled={{isSaving}}
+                      {{keyboard saveOnEnter=false}}
                     >
                       {{this.description}}
                     </textarea>

--- a/packages/frontend/app/components/school-vocabulary-term-manager.gjs
+++ b/packages/frontend/app/components/school-vocabulary-term-manager.gjs
@@ -21,6 +21,7 @@ import SchoolVocabularyNewTerm from 'frontend/components/school-vocabulary-new-t
 import YupValidationMessage from 'ilios-common/components/yup-validation-message';
 import YupValidations from 'ilios-common/classes/yup-validations';
 import { string } from 'yup';
+import focus from 'ilios-common/modifiers/focus';
 
 export default class SchoolVocabularyTermManagerComponent extends Component {
   @service store;
@@ -226,6 +227,7 @@ export default class SchoolVocabularyTermManagerComponent extends Component {
                       {{on "input" (pick "target.value" (set this "titleBuffer"))}}
                       {{this.validations.attach "title"}}
                       {{keyboard}}
+                      {{focus}}
                     />
                     <YupValidationMessage
                       @description={{t "general.title"}}
@@ -284,6 +286,7 @@ export default class SchoolVocabularyTermManagerComponent extends Component {
                       {{on "input" (pick "target.value" (set this "descriptionBuffer"))}}
                       disabled={{isSaving}}
                       {{keyboard saveOnEnter=false}}
+                      {{focus}}
                     >
                       {{this.description}}
                     </textarea>

--- a/packages/frontend/app/styles/components/program-year/objective-list.scss
+++ b/packages/frontend/app/styles/components/program-year/objective-list.scss
@@ -16,6 +16,12 @@
   }
 
   .objective-row {
+    button {
+      &.edit {
+        @include m.ilios-button;
+      }
+    }
+
     &.is-inactive {
       .grid-item {
         background-color: var(--lightest-red);

--- a/packages/frontend/app/styles/components/program-year/objectives.scss
+++ b/packages/frontend/app/styles/components/program-year/objectives.scss
@@ -4,8 +4,4 @@
 .program-year-objectives {
   @include m.detail-container(var(--orange));
   @include m.objectives;
-
-  .fade-text-control {
-    background-image: linear-gradient(to bottom, transparent, var(--white));
-  }
 }

--- a/packages/frontend/tests/acceptance/course/objectivecreate-test.js
+++ b/packages/frontend/tests/acceptance/course/objectivecreate-test.js
@@ -31,7 +31,7 @@ module('Acceptance | Course - Objective Create', function (hooks) {
     });
     assert.strictEqual(page.details.objectives.objectiveList.objectives.length, 1);
     assert.strictEqual(
-      page.details.objectives.objectiveList.objectives[0].description.text,
+      page.details.objectives.objectiveList.objectives[0].description.fadeText.displayText.text,
       'course objective 0',
     );
     await page.details.objectives.createNew();
@@ -40,13 +40,13 @@ module('Acceptance | Course - Objective Create', function (hooks) {
 
     assert.strictEqual(page.details.objectives.objectiveList.objectives.length, 2);
     assert.strictEqual(
-      page.details.objectives.objectiveList.objectives[0].description.text,
+      page.details.objectives.objectiveList.objectives[0].description.fadeText.displayText.text,
       'course objective 0',
     );
     assert.ok(page.details.objectives.objectiveList.objectives[0].parents.empty);
     assert.ok(page.details.objectives.objectiveList.objectives[0].meshDescriptors.empty);
     assert.strictEqual(
-      page.details.objectives.objectiveList.objectives[1].description.text,
+      page.details.objectives.objectiveList.objectives[1].description.fadeText.displayText.text,
       newObjectiveDescription,
     );
     assert.ok(page.details.objectives.objectiveList.objectives[1].parents.empty);
@@ -67,7 +67,7 @@ module('Acceptance | Course - Objective Create', function (hooks) {
     });
     assert.strictEqual(page.details.objectives.objectiveList.objectives.length, 1);
     assert.strictEqual(
-      page.details.objectives.objectiveList.objectives[0].description.text,
+      page.details.objectives.objectiveList.objectives[0].description.fadeText.displayText.text,
       'course objective 0',
     );
     await page.details.objectives.createNew();
@@ -76,7 +76,7 @@ module('Acceptance | Course - Objective Create', function (hooks) {
 
     assert.strictEqual(page.details.objectives.objectiveList.objectives.length, 1);
     assert.strictEqual(
-      page.details.objectives.objectiveList.objectives[0].description.text,
+      page.details.objectives.objectiveList.objectives[0].description.fadeText.displayText.text,
       'course objective 0',
     );
     assert.ok(page.details.objectives.objectiveList.objectives[0].parents.empty);
@@ -97,7 +97,7 @@ module('Acceptance | Course - Objective Create', function (hooks) {
     });
     assert.strictEqual(page.details.objectives.objectiveList.objectives.length, 1);
     assert.strictEqual(
-      page.details.objectives.objectiveList.objectives[0].description.text,
+      page.details.objectives.objectiveList.objectives[0].description.fadeText.displayText.text,
       'course objective 0',
     );
     await page.details.objectives.createNew();
@@ -133,7 +133,7 @@ module('Acceptance | Course - Objective Create', function (hooks) {
 
     assert.strictEqual(page.details.objectives.objectiveList.objectives.length, 1);
     assert.strictEqual(
-      page.details.objectives.objectiveList.objectives[0].description.text,
+      page.details.objectives.objectiveList.objectives[0].description.fadeText.displayText.text,
       newObjectiveDescription,
     );
     assert.ok(page.details.objectives.objectiveList.objectives[0].parents.empty);

--- a/packages/frontend/tests/acceptance/course/objectivelist-test.js
+++ b/packages/frontend/tests/acceptance/course/objectivelist-test.js
@@ -56,7 +56,7 @@ module('Acceptance | Course - Objective List', function (hooks) {
     assert.strictEqual(page.details.objectives.objectiveList.objectives.length, 13);
 
     assert.strictEqual(
-      page.details.objectives.objectiveList.objectives[0].description.text,
+      page.details.objectives.objectiveList.objectives[0].description.fadeText.displayText.text,
       'course objective 0',
     );
     assert.strictEqual(page.details.objectives.objectiveList.objectives[0].parents.list.length, 1);
@@ -90,7 +90,7 @@ module('Acceptance | Course - Objective List', function (hooks) {
     );
 
     assert.strictEqual(
-      page.details.objectives.objectiveList.objectives[1].description.text,
+      page.details.objectives.objectiveList.objectives[1].description.fadeText.displayText.text,
       'course objective 1',
     );
     assert.strictEqual(page.details.objectives.objectiveList.objectives[1].parents.list.length, 1);
@@ -129,7 +129,7 @@ module('Acceptance | Course - Objective List', function (hooks) {
 
     for (let i = 2; i <= 12; i++) {
       assert.strictEqual(
-        page.details.objectives.objectiveList.objectives[i].description.text,
+        page.details.objectives.objectiveList.objectives[i].description.fadeText.displayText.text,
         `course objective ${i}`,
       );
       assert.ok(page.details.objectives.objectiveList.objectives[i].parents.empty);
@@ -154,7 +154,7 @@ module('Acceptance | Course - Objective List', function (hooks) {
     });
     assert.strictEqual(page.details.objectives.objectiveList.objectives.length, 1);
     assert.strictEqual(
-      page.details.objectives.objectiveList.objectives[0].description.text,
+      page.details.objectives.objectiveList.objectives[0].description.fadeText.displayText.text,
       longTitle,
     );
     await percySnapshot(assert);
@@ -180,7 +180,7 @@ module('Acceptance | Course - Objective List', function (hooks) {
     });
     assert.strictEqual(page.details.objectives.objectiveList.objectives.length, 1);
     assert.strictEqual(
-      page.details.objectives.objectiveList.objectives[0].description.text,
+      page.details.objectives.objectiveList.objectives[0].description.fadeText.displayText.text,
       'course objective 0',
     );
     await page.details.objectives.objectiveList.objectives[0].description.openEditor();
@@ -188,7 +188,7 @@ module('Acceptance | Course - Objective List', function (hooks) {
     await page.details.objectives.objectiveList.objectives[0].description.save();
     assert.strictEqual(page.details.objectives.objectiveList.objectives.length, 1);
     assert.strictEqual(
-      page.details.objectives.objectiveList.objectives[0].description.text,
+      page.details.objectives.objectiveList.objectives[0].description.fadeText.displayText.text,
       newDescription,
     );
   });

--- a/packages/frontend/tests/acceptance/course/objectivemesh-test.js
+++ b/packages/frontend/tests/acceptance/course/objectivemesh-test.js
@@ -50,7 +50,7 @@ module('Acceptance | Course - Objective Mesh Descriptors', function (hooks) {
     assert.strictEqual(page.details.objectives.objectiveList.objectives.length, 3);
 
     assert.strictEqual(
-      page.details.objectives.objectiveList.objectives[1].description.text,
+      page.details.objectives.objectiveList.objectives[1].description.fadeText.displayText.text,
       'course objective 1',
     );
     assert.strictEqual(
@@ -127,7 +127,7 @@ module('Acceptance | Course - Objective Mesh Descriptors', function (hooks) {
     assert.strictEqual(page.details.objectives.objectiveList.objectives.length, 3);
 
     assert.strictEqual(
-      page.details.objectives.objectiveList.objectives[1].description.text,
+      page.details.objectives.objectiveList.objectives[1].description.fadeText.displayText.text,
       'course objective 1',
     );
     assert.strictEqual(
@@ -192,7 +192,7 @@ module('Acceptance | Course - Objective Mesh Descriptors', function (hooks) {
     assert.strictEqual(page.details.objectives.objectiveList.objectives.length, 3);
 
     assert.strictEqual(
-      page.details.objectives.objectiveList.objectives[1].description.text,
+      page.details.objectives.objectiveList.objectives[1].description.fadeText.displayText.text,
       'course objective 1',
     );
     assert.strictEqual(

--- a/packages/frontend/tests/acceptance/course/objectiveparents-allow-multiple-test.js
+++ b/packages/frontend/tests/acceptance/course/objectiveparents-allow-multiple-test.js
@@ -52,7 +52,7 @@ module('Acceptance | Course - Multiple Objective Parents', function (hooks) {
     assert.strictEqual(page.details.objectives.objectiveList.objectives.length, 1);
 
     assert.strictEqual(
-      page.details.objectives.objectiveList.objectives[0].description.text,
+      page.details.objectives.objectiveList.objectives[0].description.fadeText.displayText.text,
       'course objective 0',
     );
     assert.strictEqual(page.details.objectives.objectiveList.objectives[0].parents.list.length, 2);
@@ -89,7 +89,7 @@ module('Acceptance | Course - Multiple Objective Parents', function (hooks) {
       courseObjectiveDetails: true,
     });
     assert.strictEqual(
-      page.details.objectives.objectiveList.objectives[0].description.text,
+      page.details.objectives.objectiveList.objectives[0].description.fadeText.displayText.text,
       'course objective 0',
     );
     await page.details.objectives.objectiveList.objectives[0].parents.manage();
@@ -103,7 +103,7 @@ module('Acceptance | Course - Multiple Objective Parents', function (hooks) {
     await page.details.objectives.objectiveList.objectives[0].parents.save();
 
     assert.strictEqual(
-      page.details.objectives.objectiveList.objectives[0].description.text,
+      page.details.objectives.objectiveList.objectives[0].description.fadeText.displayText.text,
       'course objective 0',
     );
     assert.strictEqual(page.details.objectives.objectiveList.objectives[0].parents.list.length, 2);

--- a/packages/frontend/tests/acceptance/course/objectiveparents-description-sync-test.js
+++ b/packages/frontend/tests/acceptance/course/objectiveparents-description-sync-test.js
@@ -91,7 +91,7 @@ module('Acceptance | Course - Objective Parents - Faded Status Sync', function (
     */
 
     assert.strictEqual(
-      page.details.objectives.objectiveList.objectives[0].description.text,
+      page.details.objectives.objectiveList.objectives[0].description.fadeText.displayText.text,
       this.longObjDescription,
       '1st objective title is long',
     );
@@ -160,7 +160,7 @@ module('Acceptance | Course - Objective Parents - Faded Status Sync', function (
     */
 
     assert.strictEqual(
-      page.details.objectives.objectiveList.objectives[1].description.text,
+      page.details.objectives.objectiveList.objectives[1].description.fadeText.displayText.text,
       'course objective 1',
       '2nd objective title is short',
     );
@@ -229,7 +229,7 @@ module('Acceptance | Course - Objective Parents - Faded Status Sync', function (
     */
 
     assert.strictEqual(
-      page.details.objectives.objectiveList.objectives[2].description.text,
+      page.details.objectives.objectiveList.objectives[2].description.fadeText.displayText.text,
       this.longObjDescription,
       '3rd objective title is long',
     );

--- a/packages/frontend/tests/acceptance/course/objectiveparents-inactive-test.js
+++ b/packages/frontend/tests/acceptance/course/objectiveparents-inactive-test.js
@@ -60,7 +60,7 @@ module('Acceptance | Course - Objective Inactive Parents', function (hooks) {
     const { objectives } = page.details.objectives.objectiveList;
     assert.strictEqual(objectives.length, 1);
 
-    assert.strictEqual(objectives[0].description.text, 'course objective 0');
+    assert.strictEqual(objectives[0].description.fadeText.displayText.text, 'course objective 0');
     assert.strictEqual(objectives[0].parents.list.length, 1);
     assert.strictEqual(objectives[0].parents.list[0].text, 'inactive selected');
 

--- a/packages/frontend/tests/acceptance/course/objectiveparents-multiplecohorts-test.js
+++ b/packages/frontend/tests/acceptance/course/objectiveparents-multiplecohorts-test.js
@@ -63,7 +63,7 @@ module('Acceptance | Course with multiple Cohorts - Objective Parents', function
     assert.strictEqual(page.details.objectives.objectiveList.objectives.length, 2);
 
     assert.strictEqual(
-      page.details.objectives.objectiveList.objectives[0].description.text,
+      page.details.objectives.objectiveList.objectives[0].description.fadeText.displayText.text,
       'course objective 0',
     );
     assert.strictEqual(page.details.objectives.objectiveList.objectives[0].parents.list.length, 2);
@@ -123,7 +123,7 @@ module('Acceptance | Course with multiple Cohorts - Objective Parents', function
       courseObjectiveDetails: true,
     });
     assert.strictEqual(
-      page.details.objectives.objectiveList.objectives[0].description.text,
+      page.details.objectives.objectiveList.objectives[0].description.fadeText.displayText.text,
       'course objective 0',
     );
     assert.strictEqual(page.details.objectives.objectiveList.objectives[0].parents.list.length, 2);
@@ -151,7 +151,7 @@ module('Acceptance | Course with multiple Cohorts - Objective Parents', function
     await page.details.objectives.objectiveList.objectives[0].parents.save();
 
     assert.strictEqual(
-      page.details.objectives.objectiveList.objectives[0].description.text,
+      page.details.objectives.objectiveList.objectives[0].description.fadeText.displayText.text,
       'course objective 0',
     );
     assert.strictEqual(page.details.objectives.objectiveList.objectives[0].parents.list.length, 2);
@@ -173,7 +173,7 @@ module('Acceptance | Course with multiple Cohorts - Objective Parents', function
       courseObjectiveDetails: true,
     });
     assert.strictEqual(
-      page.details.objectives.objectiveList.objectives[0].description.text,
+      page.details.objectives.objectiveList.objectives[0].description.fadeText.displayText.text,
       'course objective 0',
     );
     assert.strictEqual(page.details.objectives.objectiveList.objectives[0].parents.list.length, 2);
@@ -201,7 +201,7 @@ module('Acceptance | Course with multiple Cohorts - Objective Parents', function
     await page.details.objectives.objectiveList.objectives[0].parents.cancel();
 
     assert.strictEqual(
-      page.details.objectives.objectiveList.objectives[0].description.text,
+      page.details.objectives.objectiveList.objectives[0].description.fadeText.displayText.text,
       'course objective 0',
     );
     assert.strictEqual(page.details.objectives.objectiveList.objectives[0].parents.list.length, 2);

--- a/packages/frontend/tests/acceptance/course/objectiveparents-nocohorts-test.js
+++ b/packages/frontend/tests/acceptance/course/objectiveparents-nocohorts-test.js
@@ -39,7 +39,7 @@ module('Acceptance | Course with no cohorts - Objective Parents', function (hook
     assert.strictEqual(page.details.objectives.objectiveList.objectives.length, 1);
     const firstObjective = page.details.objectives.objectiveList.objectives[0];
 
-    assert.strictEqual(firstObjective.description.text, 'course objective 0');
+    assert.strictEqual(firstObjective.description.fadeText.displayText.text, 'course objective 0');
     assert.ok(firstObjective.parents.empty);
     await firstObjective.parents.manage();
     const m = firstObjective.parentManager;

--- a/packages/frontend/tests/acceptance/course/objectiveparents-test.js
+++ b/packages/frontend/tests/acceptance/course/objectiveparents-test.js
@@ -57,7 +57,7 @@ module('Acceptance | Course - Objective Parents', function (hooks) {
     assert.strictEqual(page.details.objectives.objectiveList.objectives.length, 2);
 
     assert.strictEqual(
-      page.details.objectives.objectiveList.objectives[0].description.text,
+      page.details.objectives.objectiveList.objectives[0].description.fadeText.displayText.text,
       'course objective 0',
     );
     assert.strictEqual(page.details.objectives.objectiveList.objectives[0].parents.list.length, 1);
@@ -98,7 +98,7 @@ module('Acceptance | Course - Objective Parents', function (hooks) {
     assert.strictEqual(page.details.objectives.objectiveList.objectives.length, 2);
 
     assert.strictEqual(
-      page.details.objectives.objectiveList.objectives[0].description.text,
+      page.details.objectives.objectiveList.objectives[0].description.fadeText.displayText.text,
       'course objective 0',
     );
     assert.strictEqual(page.details.objectives.objectiveList.objectives[0].parents.list.length, 1);
@@ -119,7 +119,7 @@ module('Acceptance | Course - Objective Parents', function (hooks) {
     await page.details.objectives.objectiveList.objectives[0].parents.save();
 
     assert.strictEqual(
-      page.details.objectives.objectiveList.objectives[0].description.text,
+      page.details.objectives.objectiveList.objectives[0].description.fadeText.displayText.text,
       'course objective 0',
     );
     assert.strictEqual(page.details.objectives.objectiveList.objectives[0].parents.list.length, 1);
@@ -141,7 +141,7 @@ module('Acceptance | Course - Objective Parents', function (hooks) {
     assert.strictEqual(page.details.objectives.objectiveList.objectives.length, 2);
 
     assert.strictEqual(
-      page.details.objectives.objectiveList.objectives[0].description.text,
+      page.details.objectives.objectiveList.objectives[0].description.fadeText.displayText.text,
       'course objective 0',
     );
     assert.strictEqual(page.details.objectives.objectiveList.objectives[0].parents.list.length, 1);
@@ -163,7 +163,7 @@ module('Acceptance | Course - Objective Parents', function (hooks) {
     await page.details.objectives.objectiveList.objectives[0].parents.cancel();
 
     assert.strictEqual(
-      page.details.objectives.objectiveList.objectives[0].description.text,
+      page.details.objectives.objectiveList.objectives[0].description.fadeText.displayText.text,
       'course objective 0',
     );
     assert.strictEqual(page.details.objectives.objectiveList.objectives[0].parents.list.length, 1);

--- a/packages/frontend/tests/acceptance/course/objectiveterms-test.js
+++ b/packages/frontend/tests/acceptance/course/objectiveterms-test.js
@@ -37,7 +37,7 @@ module('Acceptance | Course - Objective Vocabulary Terms', function (hooks) {
       1,
     );
     assert.strictEqual(
-      page.details.objectives.objectiveList.objectives[0].description.text,
+      page.details.objectives.objectiveList.objectives[0].description.fadeText.displayText.text,
       'course objective 0',
     );
     assert.strictEqual(
@@ -145,7 +145,7 @@ module('Acceptance | Course - Objective Vocabulary Terms', function (hooks) {
       1,
     );
     assert.strictEqual(
-      page.details.objectives.objectiveList.objectives[0].description.text,
+      page.details.objectives.objectiveList.objectives[0].description.fadeText.displayText.text,
       'course objective 0',
     );
     assert.strictEqual(

--- a/packages/frontend/tests/acceptance/course/session/objectivecreate-test.js
+++ b/packages/frontend/tests/acceptance/course/session/objectivecreate-test.js
@@ -36,7 +36,7 @@ module('Acceptance | Session - Objective Create', function (hooks) {
     });
     assert.strictEqual(page.details.objectives.objectiveList.objectives.length, 1);
     assert.strictEqual(
-      page.details.objectives.objectiveList.objectives[0].description.text,
+      page.details.objectives.objectiveList.objectives[0].description.fadeText.displayText.text,
       'session objective 0',
     );
     await page.details.objectives.createNew();
@@ -45,13 +45,13 @@ module('Acceptance | Session - Objective Create', function (hooks) {
 
     assert.strictEqual(page.details.objectives.objectiveList.objectives.length, 2);
     assert.strictEqual(
-      page.details.objectives.objectiveList.objectives[0].description.text,
+      page.details.objectives.objectiveList.objectives[0].description.fadeText.displayText.text,
       'session objective 0',
     );
     assert.ok(page.details.objectives.objectiveList.objectives[0].parents.empty);
     assert.ok(page.details.objectives.objectiveList.objectives[0].meshDescriptors.empty);
     assert.strictEqual(
-      page.details.objectives.objectiveList.objectives[1].description.text,
+      page.details.objectives.objectiveList.objectives[1].description.fadeText.displayText.text,
       newObjectiveDescription,
     );
     assert.ok(page.details.objectives.objectiveList.objectives[0].parents.empty);
@@ -67,7 +67,7 @@ module('Acceptance | Session - Objective Create', function (hooks) {
     });
     assert.strictEqual(page.details.objectives.objectiveList.objectives.length, 1);
     assert.strictEqual(
-      page.details.objectives.objectiveList.objectives[0].description.text,
+      page.details.objectives.objectiveList.objectives[0].description.fadeText.displayText.text,
       'session objective 0',
     );
     await page.details.objectives.createNew();
@@ -76,7 +76,7 @@ module('Acceptance | Session - Objective Create', function (hooks) {
 
     assert.strictEqual(page.details.objectives.objectiveList.objectives.length, 1);
     assert.strictEqual(
-      page.details.objectives.objectiveList.objectives[0].description.text,
+      page.details.objectives.objectiveList.objectives[0].description.fadeText.displayText.text,
       'session objective 0',
     );
     assert.ok(page.details.objectives.objectiveList.objectives[0].parents.empty);
@@ -92,7 +92,7 @@ module('Acceptance | Session - Objective Create', function (hooks) {
     });
     assert.strictEqual(page.details.objectives.objectiveList.objectives.length, 1);
     assert.strictEqual(
-      page.details.objectives.objectiveList.objectives[0].description.text,
+      page.details.objectives.objectiveList.objectives[0].description.fadeText.displayText.text,
       'session objective 0',
     );
     await page.details.objectives.createNew();

--- a/packages/frontend/tests/acceptance/course/session/objectivelist-test.js
+++ b/packages/frontend/tests/acceptance/course/session/objectivelist-test.js
@@ -55,7 +55,7 @@ module('Acceptance | Session - Objective List', function (hooks) {
     assert.strictEqual(page.details.objectives.objectiveList.objectives.length, 13);
 
     assert.strictEqual(
-      page.details.objectives.objectiveList.objectives[0].description.text,
+      page.details.objectives.objectiveList.objectives[0].description.fadeText.displayText.text,
       'session objective 0',
     );
     assert.strictEqual(page.details.objectives.objectiveList.objectives[0].parents.list.length, 1);
@@ -89,7 +89,7 @@ module('Acceptance | Session - Objective List', function (hooks) {
     );
 
     assert.strictEqual(
-      page.details.objectives.objectiveList.objectives[1].description.text,
+      page.details.objectives.objectiveList.objectives[1].description.fadeText.displayText.text,
       'session objective 1',
     );
     assert.strictEqual(page.details.objectives.objectiveList.objectives[1].parents.list.length, 1);
@@ -128,7 +128,7 @@ module('Acceptance | Session - Objective List', function (hooks) {
 
     for (let i = 2; i <= 12; i++) {
       assert.strictEqual(
-        page.details.objectives.objectiveList.objectives[i].description.text,
+        page.details.objectives.objectiveList.objectives[i].description.fadeText.displayText.text,
         `session objective ${i}`,
       );
       assert.ok(page.details.objectives.objectiveList.objectives[i].parents.empty);
@@ -150,7 +150,7 @@ module('Acceptance | Session - Objective List', function (hooks) {
     });
     assert.strictEqual(page.details.objectives.objectiveList.objectives.length, 1);
     assert.strictEqual(
-      page.details.objectives.objectiveList.objectives[0].description.text,
+      page.details.objectives.objectiveList.objectives[0].description.fadeText.displayText.text,
       longTitle,
     );
     await page.details.objectives.objectiveList.objectives[0].description.openEditor();
@@ -173,7 +173,7 @@ module('Acceptance | Session - Objective List', function (hooks) {
     });
     assert.strictEqual(page.details.objectives.objectiveList.objectives.length, 1);
     assert.strictEqual(
-      page.details.objectives.objectiveList.objectives[0].description.text,
+      page.details.objectives.objectiveList.objectives[0].description.fadeText.displayText.text,
       'session objective 0',
     );
     await page.details.objectives.objectiveList.objectives[0].description.openEditor();
@@ -181,7 +181,7 @@ module('Acceptance | Session - Objective List', function (hooks) {
     await page.details.objectives.objectiveList.objectives[0].description.save();
     assert.strictEqual(page.details.objectives.objectiveList.objectives.length, 1);
     assert.strictEqual(
-      page.details.objectives.objectiveList.objectives[0].description.text,
+      page.details.objectives.objectiveList.objectives[0].description.fadeText.displayText.text,
       newDescription,
     );
   });

--- a/packages/frontend/tests/acceptance/course/session/objectivemesh-test.js
+++ b/packages/frontend/tests/acceptance/course/session/objectivemesh-test.js
@@ -47,7 +47,7 @@ module('Acceptance | Session - Objective Mesh Descriptors', function (hooks) {
     assert.strictEqual(page.details.objectives.objectiveList.objectives.length, 3);
 
     assert.strictEqual(
-      page.details.objectives.objectiveList.objectives[1].description.text,
+      page.details.objectives.objectiveList.objectives[1].description.fadeText.displayText.text,
       'session objective 1',
     );
     assert.strictEqual(
@@ -124,7 +124,7 @@ module('Acceptance | Session - Objective Mesh Descriptors', function (hooks) {
     assert.strictEqual(page.details.objectives.objectiveList.objectives.length, 3);
 
     assert.strictEqual(
-      page.details.objectives.objectiveList.objectives[1].description.text,
+      page.details.objectives.objectiveList.objectives[1].description.fadeText.displayText.text,
       'session objective 1',
     );
     assert.strictEqual(
@@ -188,7 +188,7 @@ module('Acceptance | Session - Objective Mesh Descriptors', function (hooks) {
     assert.strictEqual(page.details.objectives.objectiveList.objectives.length, 3);
 
     assert.strictEqual(
-      page.details.objectives.objectiveList.objectives[1].description.text,
+      page.details.objectives.objectiveList.objectives[1].description.fadeText.displayText.text,
       'session objective 1',
     );
     assert.strictEqual(

--- a/packages/frontend/tests/acceptance/course/session/objectiveparents-description-sync-test.js
+++ b/packages/frontend/tests/acceptance/course/session/objectiveparents-description-sync-test.js
@@ -107,7 +107,7 @@ module('Acceptance | Session - Objective Parents - Faded Status Sync', function 
     */
 
     assert.strictEqual(
-      page.details.objectives.objectiveList.objectives[0].description.text,
+      page.details.objectives.objectiveList.objectives[0].description.fadeText.displayText.text,
       this.longObjDescription,
       '1st objective title is long',
     );
@@ -176,7 +176,7 @@ module('Acceptance | Session - Objective Parents - Faded Status Sync', function 
     */
 
     assert.strictEqual(
-      page.details.objectives.objectiveList.objectives[1].description.text,
+      page.details.objectives.objectiveList.objectives[1].description.fadeText.displayText.text,
       'session objective 1',
       '2nd objective title is short',
     );
@@ -245,7 +245,7 @@ module('Acceptance | Session - Objective Parents - Faded Status Sync', function 
     */
 
     assert.strictEqual(
-      page.details.objectives.objectiveList.objectives[2].description.text,
+      page.details.objectives.objectiveList.objectives[2].description.fadeText.displayText.text,
       this.longObjDescription,
       '3rd objective title is long',
     );

--- a/packages/frontend/tests/acceptance/course/session/objectiveparents-test.js
+++ b/packages/frontend/tests/acceptance/course/session/objectiveparents-test.js
@@ -38,7 +38,7 @@ module('Acceptance | Session - Objective Parents', function (hooks) {
     assert.strictEqual(page.details.objectives.objectiveList.objectives.length, 2);
 
     assert.strictEqual(
-      page.details.objectives.objectiveList.objectives[0].description.text,
+      page.details.objectives.objectiveList.objectives[0].description.fadeText.displayText.text,
       'session objective 0',
     );
     assert.strictEqual(page.details.objectives.objectiveList.objectives[0].parents.list.length, 2);
@@ -77,7 +77,7 @@ module('Acceptance | Session - Objective Parents', function (hooks) {
     });
 
     assert.strictEqual(
-      page.details.objectives.objectiveList.objectives[0].description.text,
+      page.details.objectives.objectiveList.objectives[0].description.fadeText.displayText.text,
       'session objective 0',
     );
     assert.strictEqual(page.details.objectives.objectiveList.objectives[0].parents.list.length, 2);
@@ -104,7 +104,7 @@ module('Acceptance | Session - Objective Parents', function (hooks) {
     await page.details.objectives.objectiveList.objectives[0].parents.save();
 
     assert.strictEqual(
-      page.details.objectives.objectiveList.objectives[0].description.text,
+      page.details.objectives.objectiveList.objectives[0].description.fadeText.displayText.text,
       'session objective 0',
     );
     assert.strictEqual(page.details.objectives.objectiveList.objectives[0].parents.list.length, 2);
@@ -129,7 +129,7 @@ module('Acceptance | Session - Objective Parents', function (hooks) {
     });
 
     assert.strictEqual(
-      page.details.objectives.objectiveList.objectives[0].description.text,
+      page.details.objectives.objectiveList.objectives[0].description.fadeText.displayText.text,
       'session objective 0',
     );
     assert.strictEqual(page.details.objectives.objectiveList.objectives[0].parents.list.length, 2);
@@ -156,7 +156,7 @@ module('Acceptance | Session - Objective Parents', function (hooks) {
     await page.details.objectives.objectiveList.objectives[0].parents.cancel();
 
     assert.strictEqual(
-      page.details.objectives.objectiveList.objectives[0].description.text,
+      page.details.objectives.objectiveList.objectives[0].description.fadeText.displayText.text,
       'session objective 0',
     );
     assert.strictEqual(page.details.objectives.objectiveList.objectives[0].parents.list.length, 2);
@@ -181,7 +181,7 @@ module('Acceptance | Session - Objective Parents', function (hooks) {
     });
 
     assert.strictEqual(
-      page.details.objectives.objectiveList.objectives[0].description.text,
+      page.details.objectives.objectiveList.objectives[0].description.fadeText.displayText.text,
       'session objective 0',
     );
     assert.strictEqual(page.details.objectives.objectiveList.objectives[0].parents.list.length, 2);
@@ -208,7 +208,7 @@ module('Acceptance | Session - Objective Parents', function (hooks) {
     await page.details.objectives.objectiveList.objectives[0].parents.save();
 
     assert.strictEqual(
-      page.details.objectives.objectiveList.objectives[0].description.text,
+      page.details.objectives.objectiveList.objectives[0].description.fadeText.displayText.text,
       'session objective 0',
     );
     assert.ok(page.details.objectives.objectiveList.objectives[0].parents.empty);

--- a/packages/frontend/tests/acceptance/course/session/objectiveterms-test.js
+++ b/packages/frontend/tests/acceptance/course/session/objectiveterms-test.js
@@ -39,7 +39,7 @@ module('Acceptance | Session - Objective Vocabulary Terms', function (hooks) {
       1,
     );
     assert.strictEqual(
-      page.details.objectives.objectiveList.objectives[0].description.text,
+      page.details.objectives.objectiveList.objectives[0].description.fadeText.displayText.text,
       'session objective 0',
     );
     assert.strictEqual(
@@ -147,7 +147,7 @@ module('Acceptance | Session - Objective Vocabulary Terms', function (hooks) {
       1,
     );
     assert.strictEqual(
-      page.details.objectives.objectiveList.objectives[0].description.text,
+      page.details.objectives.objectiveList.objectives[0].description.fadeText.displayText.text,
       'session objective 0',
     );
     assert.strictEqual(

--- a/packages/frontend/tests/acceptance/course/session/overview-test.js
+++ b/packages/frontend/tests/acceptance/course/session/overview-test.js
@@ -35,8 +35,14 @@ module('Acceptance | Session - Overview', function (hooks) {
     });
     await page.visit({ courseId: 1, sessionId: 1 });
     assert.strictEqual(page.details.overview.sessionType.value, 'session type 0');
-    assert.strictEqual(page.details.overview.sessionDescription.value, session.description);
-    assert.strictEqual(page.details.overview.instructionalNotes.value, 'session notes');
+    assert.strictEqual(
+      page.details.overview.sessionDescription.fadeText.displayText.text,
+      session.description,
+    );
+    assert.strictEqual(
+      page.details.overview.instructionalNotes.fadeText.displayText.text,
+      'session notes',
+    );
     assert.notOk(page.details.overview.ilm.ilmHours.isVisible);
   });
 
@@ -481,11 +487,17 @@ module('Acceptance | Session - Overview', function (hooks) {
     await page.visit({ courseId: 1, sessionId: 1 });
 
     assert.strictEqual(currentRouteName(), 'session.index');
-    assert.strictEqual(page.details.overview.sessionDescription.value, session.description);
+    assert.strictEqual(
+      page.details.overview.sessionDescription.fadeText.displayText.text,
+      session.description,
+    );
     await page.details.overview.sessionDescription.edit();
     await page.details.overview.sessionDescription.set(newDescription);
     await page.details.overview.sessionDescription.save();
-    assert.strictEqual(page.details.overview.sessionDescription.value, newDescription);
+    assert.strictEqual(
+      page.details.overview.sessionDescription.fadeText.displayText.text,
+      newDescription,
+    );
   });
 
   test('add description', async function (assert) {
@@ -505,11 +517,14 @@ module('Acceptance | Session - Overview', function (hooks) {
     await page.visit({ courseId: 1, sessionId: 1 });
 
     assert.strictEqual(currentRouteName(), 'session.index');
-    assert.strictEqual(page.details.overview.sessionDescription.value, 'Click to edit');
+    assert.strictEqual(page.details.overview.sessionDescription.text, 'Click to edit');
     await page.details.overview.sessionDescription.edit();
     await page.details.overview.sessionDescription.set(newDescription);
     await page.details.overview.sessionDescription.save();
-    assert.strictEqual(page.details.overview.sessionDescription.value, newDescription);
+    assert.strictEqual(
+      page.details.overview.sessionDescription.fadeText.displayText.text,
+      newDescription,
+    );
   });
 
   test('empty description removes description', async function (assert) {
@@ -528,11 +543,11 @@ module('Acceptance | Session - Overview', function (hooks) {
     await page.visit({ courseId: 1, sessionId: 1 });
 
     assert.strictEqual(currentRouteName(), 'session.index');
-    assert.strictEqual(page.details.overview.sessionDescription.value, 'Click to edit');
+    assert.strictEqual(page.details.overview.sessionDescription.text, 'Click to edit');
     await page.details.overview.sessionDescription.edit();
     await page.details.overview.sessionDescription.set('<p>&nbsp</p><div></div><span>  </span>');
     await page.details.overview.sessionDescription.save();
-    assert.strictEqual(page.details.overview.sessionDescription.value, 'Click to edit');
+    assert.strictEqual(page.details.overview.sessionDescription.text, 'Click to edit');
   });
 
   test('remove description', async function (assert) {
@@ -550,11 +565,14 @@ module('Acceptance | Session - Overview', function (hooks) {
     await page.visit({ courseId: 1, sessionId: 1 });
 
     assert.strictEqual(currentRouteName(), 'session.index');
-    assert.strictEqual(page.details.overview.sessionDescription.value, session.description);
+    assert.strictEqual(
+      page.details.overview.sessionDescription.fadeText.displayText.text,
+      session.description,
+    );
     await page.details.overview.sessionDescription.edit();
     await page.details.overview.sessionDescription.set('<p>&nbsp</p><div></div><span>  </span>');
     await page.details.overview.sessionDescription.save();
-    assert.strictEqual(page.details.overview.sessionDescription.value, 'Click to edit');
+    assert.strictEqual(page.details.overview.sessionDescription.text, 'Click to edit');
   });
 
   test('cancel editing empty description #3210', async function (assert) {
@@ -573,11 +591,11 @@ module('Acceptance | Session - Overview', function (hooks) {
     await page.visit({ courseId: 1, sessionId: 1 });
 
     assert.strictEqual(currentRouteName(), 'session.index');
-    assert.strictEqual(page.details.overview.sessionDescription.value, 'Click to edit');
+    assert.strictEqual(page.details.overview.sessionDescription.text, 'Click to edit');
     await page.details.overview.sessionDescription.edit();
     await page.details.overview.sessionDescription.set('something useless this way types');
     await page.details.overview.sessionDescription.cancel();
-    assert.strictEqual(page.details.overview.sessionDescription.value, 'Click to edit');
+    assert.strictEqual(page.details.overview.sessionDescription.text, 'Click to edit');
   });
 
   test('click copy', async function (assert) {
@@ -654,7 +672,7 @@ module('Acceptance | Session - Overview', function (hooks) {
 
     assert.strictEqual(currentRouteName(), 'session.index', 'route name is correct');
     assert.strictEqual(
-      page.details.overview.instructionalNotes.value,
+      page.details.overview.instructionalNotes.fadeText.displayText.text,
       'instructional note',
       'instructional notes value is correct',
     );
@@ -662,7 +680,7 @@ module('Acceptance | Session - Overview', function (hooks) {
     await page.details.overview.instructionalNotes.set(newInstructionalNotes);
     await page.details.overview.instructionalNotes.save();
     assert.strictEqual(
-      page.details.overview.instructionalNotes.value,
+      page.details.overview.instructionalNotes.fadeText.displayText.text,
       newInstructionalNotes,
       'new instructional notes value is correct',
     );
@@ -690,7 +708,7 @@ module('Acceptance | Session - Overview', function (hooks) {
 
     assert.strictEqual(currentRouteName(), 'session.index', 'route name is correct');
     assert.strictEqual(
-      page.details.overview.instructionalNotes.value,
+      page.details.overview.instructionalNotes.text,
       'Click to edit',
       'initial instructional notes value is correct',
     );
@@ -698,7 +716,7 @@ module('Acceptance | Session - Overview', function (hooks) {
     await page.details.overview.instructionalNotes.set(newInstructionalNotes);
     await page.details.overview.instructionalNotes.save();
     assert.strictEqual(
-      page.details.overview.instructionalNotes.value,
+      page.details.overview.instructionalNotes.fadeText.displayText.text,
       newInstructionalNotes,
       'new instructional notes value is correct',
     );
@@ -724,11 +742,11 @@ module('Acceptance | Session - Overview', function (hooks) {
     await page.visit({ courseId: 1, sessionId: 1 });
 
     assert.strictEqual(currentRouteName(), 'session.index');
-    assert.strictEqual(page.details.overview.instructionalNotes.value, 'Click to edit');
+    assert.strictEqual(page.details.overview.instructionalNotes.text, 'Click to edit');
     await page.details.overview.instructionalNotes.edit();
     await page.details.overview.instructionalNotes.set('<p>&nbsp</p><div></div><span>  </span>');
     await page.details.overview.instructionalNotes.save();
-    assert.strictEqual(page.details.overview.instructionalNotes.value, 'Click to edit');
+    assert.strictEqual(page.details.overview.instructionalNotes.text, 'Click to edit');
     assert.strictEqual(this.server.db.sessions[0].instructionalNotes, null);
   });
 
@@ -748,11 +766,14 @@ module('Acceptance | Session - Overview', function (hooks) {
     await page.visit({ courseId: 1, sessionId: 1 });
 
     assert.strictEqual(currentRouteName(), 'session.index');
-    assert.strictEqual(page.details.overview.instructionalNotes.value, 'instructional note');
+    assert.strictEqual(
+      page.details.overview.instructionalNotes.fadeText.displayText.text,
+      'instructional note',
+    );
     await page.details.overview.instructionalNotes.edit();
     await page.details.overview.instructionalNotes.set('<p>&nbsp</p><div></div><span>  </span>');
     await page.details.overview.instructionalNotes.save();
-    assert.strictEqual(page.details.overview.instructionalNotes.value, 'Click to edit');
+    assert.strictEqual(page.details.overview.instructionalNotes.text, 'Click to edit');
   });
 
   test('cancel editing empty instructionalNotes #3210', async function (assert) {
@@ -770,11 +791,11 @@ module('Acceptance | Session - Overview', function (hooks) {
     await page.visit({ courseId: 1, sessionId: 1 });
 
     assert.strictEqual(currentRouteName(), 'session.index');
-    assert.strictEqual(page.details.overview.instructionalNotes.value, 'Click to edit');
+    assert.strictEqual(page.details.overview.instructionalNotes.text, 'Click to edit');
     await page.details.overview.instructionalNotes.edit();
     await page.details.overview.instructionalNotes.set('something useless this way types');
     await page.details.overview.instructionalNotes.cancel();
-    assert.strictEqual(page.details.overview.instructionalNotes.value, 'Click to edit');
+    assert.strictEqual(page.details.overview.instructionalNotes.text, 'Click to edit');
   });
 
   test('has no pre-requisite', async function (assert) {

--- a/packages/frontend/tests/acceptance/program-year/objectives-test.js
+++ b/packages/frontend/tests/acceptance/program-year/objectives-test.js
@@ -73,7 +73,7 @@ module('Acceptance | Program Year - Objectives', function (hooks) {
     await percySnapshot(assert);
     assert.strictEqual(page.details.objectives.objectiveList.objectives.length, 3);
     assert.strictEqual(
-      page.details.objectives.objectiveList.objectives[0].description.text,
+      page.details.objectives.objectiveList.objectives[0].description.fadeText.displayText.text,
       'program-year objective 0',
     );
     assert.ok(page.details.objectives.objectiveList.objectives[0].competency.hasCompetency);
@@ -112,7 +112,7 @@ module('Acceptance | Program Year - Objectives', function (hooks) {
     );
 
     assert.strictEqual(
-      page.details.objectives.objectiveList.objectives[1].description.text,
+      page.details.objectives.objectiveList.objectives[1].description.fadeText.displayText.text,
       'program-year objective 1',
     );
     assert.ok(page.details.objectives.objectiveList.objectives[1].competency.hasCompetency);
@@ -136,7 +136,7 @@ module('Acceptance | Program Year - Objectives', function (hooks) {
     );
 
     assert.strictEqual(
-      page.details.objectives.objectiveList.objectives[2].description.text,
+      page.details.objectives.objectiveList.objectives[2].description.fadeText.displayText.text,
       'program-year objective 2',
     );
     assert.notOk(page.details.objectives.objectiveList.objectives[2].competency.hasCompetency);
@@ -151,7 +151,7 @@ module('Acceptance | Program Year - Objectives', function (hooks) {
     await percySnapshot(assert);
     assert.strictEqual(page.details.objectives.objectiveList.objectives.length, 3);
     assert.strictEqual(
-      page.details.objectives.objectiveList.objectives[0].description.text,
+      page.details.objectives.objectiveList.objectives[0].description.fadeText.displayText.text,
       'program-year objective 0',
     );
     assert.ok(page.details.objectives.objectiveList.objectives[0].competency.hasCompetency);
@@ -178,7 +178,7 @@ module('Acceptance | Program Year - Objectives', function (hooks) {
     );
 
     assert.strictEqual(
-      page.details.objectives.objectiveList.objectives[1].description.text,
+      page.details.objectives.objectiveList.objectives[1].description.fadeText.displayText.text,
       'program-year objective 1',
     );
     assert.ok(page.details.objectives.objectiveList.objectives[1].competency.hasCompetency);
@@ -190,7 +190,7 @@ module('Acceptance | Program Year - Objectives', function (hooks) {
     assert.ok(page.details.objectives.objectiveList.objectives[1].meshDescriptors.isEmpty);
 
     assert.strictEqual(
-      page.details.objectives.objectiveList.objectives[2].description.text,
+      page.details.objectives.objectiveList.objectives[2].description.fadeText.displayText.text,
       'program-year objective 2',
     );
     assert.notOk(page.details.objectives.objectiveList.objectives[2].competency.hasCompetency);
@@ -205,7 +205,7 @@ module('Acceptance | Program Year - Objectives', function (hooks) {
     assert.strictEqual(page.details.objectives.objectiveList.objectives.length, 3);
 
     assert.strictEqual(
-      page.details.objectives.objectiveList.objectives[0].description.text,
+      page.details.objectives.objectiveList.objectives[0].description.fadeText.displayText.text,
       'program-year objective 0',
     );
     assert.strictEqual(
@@ -255,7 +255,7 @@ module('Acceptance | Program Year - Objectives', function (hooks) {
     assert.strictEqual(page.details.objectives.objectiveList.objectives.length, 3);
 
     assert.strictEqual(
-      page.details.objectives.objectiveList.objectives[0].description.text,
+      page.details.objectives.objectiveList.objectives[0].description.fadeText.displayText.text,
       'program-year objective 0',
     );
     assert.strictEqual(
@@ -297,7 +297,7 @@ module('Acceptance | Program Year - Objectives', function (hooks) {
     assert.strictEqual(page.details.objectives.objectiveList.objectives.length, 3);
 
     assert.strictEqual(
-      page.details.objectives.objectiveList.objectives[0].description.text,
+      page.details.objectives.objectiveList.objectives[0].description.fadeText.displayText.text,
       'program-year objective 0',
     );
     assert.strictEqual(
@@ -368,7 +368,7 @@ module('Acceptance | Program Year - Objectives', function (hooks) {
     await page.details.objectives.objectiveList.objectives[0].competency.save();
 
     assert.strictEqual(
-      page.details.objectives.objectiveList.objectives[0].description.text,
+      page.details.objectives.objectiveList.objectives[0].description.fadeText.displayText.text,
       'program-year objective 0',
     );
     assert.ok(page.details.objectives.objectiveList.objectives[0].competency.hasCompetency);
@@ -395,7 +395,7 @@ module('Acceptance | Program Year - Objectives', function (hooks) {
     await page.details.objectives.objectiveList.objectives[0].competency.save();
 
     assert.strictEqual(
-      page.details.objectives.objectiveList.objectives[0].description.text,
+      page.details.objectives.objectiveList.objectives[0].description.fadeText.displayText.text,
       'program-year objective 0',
     );
     assert.notOk(page.details.objectives.objectiveList.objectives[0].competency.hasCompetency);
@@ -414,7 +414,7 @@ module('Acceptance | Program Year - Objectives', function (hooks) {
     await page.details.objectives.objectiveList.objectives[0].competency.cancel();
 
     assert.strictEqual(
-      page.details.objectives.objectiveList.objectives[0].description.text,
+      page.details.objectives.objectiveList.objectives[0].description.fadeText.displayText.text,
       'program-year objective 0',
     );
     assert.ok(page.details.objectives.objectiveList.objectives[0].competency.hasCompetency);
@@ -442,7 +442,7 @@ module('Acceptance | Program Year - Objectives', function (hooks) {
     await page.details.objectives.objectiveList.objectives[0].competency.cancel();
 
     assert.strictEqual(
-      page.details.objectives.objectiveList.objectives[0].description.text,
+      page.details.objectives.objectiveList.objectives[0].description.fadeText.displayText.text,
       'program-year objective 0',
     );
     assert.ok(page.details.objectives.objectiveList.objectives[0].competency.hasCompetency);
@@ -462,7 +462,7 @@ module('Acceptance | Program Year - Objectives', function (hooks) {
     assert.expect(10);
     await page.visit({ programId: 1, programYearId: 1, pyObjectiveDetails: true });
     assert.strictEqual(
-      page.details.objectives.objectiveList.objectives[2].description.text,
+      page.details.objectives.objectiveList.objectives[2].description.fadeText.displayText.text,
       'program-year objective 2',
     );
     assert.notOk(page.details.objectives.objectiveList.objectives[2].competency.hasCompetency);
@@ -476,7 +476,7 @@ module('Acceptance | Program Year - Objectives', function (hooks) {
     await page.details.objectives.objectiveList.objectives[2].competency.save();
 
     assert.strictEqual(
-      page.details.objectives.objectiveList.objectives[2].description.text,
+      page.details.objectives.objectiveList.objectives[2].description.fadeText.displayText.text,
       'program-year objective 2',
     );
     assert.ok(page.details.objectives.objectiveList.objectives[2].competency.hasCompetency);
@@ -497,7 +497,7 @@ module('Acceptance | Program Year - Objectives', function (hooks) {
     await page.visit({ programId: 1, programYearId: 1, pyObjectiveDetails: true });
     assert.strictEqual(page.details.objectives.objectiveList.objectives.length, 3);
     assert.strictEqual(
-      page.details.objectives.objectiveList.objectives[0].description.text,
+      page.details.objectives.objectiveList.objectives[0].description.fadeText.displayText.text,
       'program-year objective 0',
     );
     await page.details.objectives.createNew();
@@ -517,7 +517,7 @@ module('Acceptance | Program Year - Objectives', function (hooks) {
     assert.expect(6);
     await page.visit({ programId: 1, programYearId: 1, pyObjectiveDetails: true });
     assert.strictEqual(
-      page.details.objectives.objectiveList.objectives[0].description.text,
+      page.details.objectives.objectiveList.objectives[0].description.fadeText.displayText.text,
       'program-year objective 0',
     );
     assert.strictEqual(page.details.objectives.objectiveList.expanded.length, 0);

--- a/packages/frontend/tests/acceptance/program-year/objectiveterms-test.js
+++ b/packages/frontend/tests/acceptance/program-year/objectiveterms-test.js
@@ -37,7 +37,7 @@ module('Acceptance | Program Year - Objective Vocabulary Terms', function (hooks
       1,
     );
     assert.strictEqual(
-      page.details.objectives.objectiveList.objectives[0].description.text,
+      page.details.objectives.objectiveList.objectives[0].description.fadeText.displayText.text,
       'program-year objective 0',
     );
     assert.strictEqual(
@@ -165,7 +165,7 @@ module('Acceptance | Program Year - Objective Vocabulary Terms', function (hooks
       1,
     );
     assert.strictEqual(
-      page.details.objectives.objectiveList.objectives[0].description.text,
+      page.details.objectives.objectiveList.objectives[0].description.fadeText.displayText.text,
       'program-year objective 0',
     );
     assert.strictEqual(

--- a/packages/frontend/tests/integration/components/program-year/objective-list-item-test.gjs
+++ b/packages/frontend/tests/integration/components/program-year/objective-list-item-test.gjs
@@ -34,7 +34,7 @@ module('Integration | Component | program-year/objective-list-item', function (h
       </template>,
     );
     assert.notOk(component.hasRemoveConfirmation);
-    assert.strictEqual(component.description.text, 'program-year objective 0');
+    assert.strictEqual(component.description.fadeText.displayText.text, 'program-year objective 0');
     assert.strictEqual(component.competency.text, 'Add New');
     assert.strictEqual(component.meshDescriptors.text, 'Add New');
     assert.ok(component.isActive);
@@ -51,11 +51,11 @@ module('Integration | Component | program-year/objective-list-item', function (h
       </template>,
     );
     const newDescription = 'Pluto Visits Earth';
-    assert.strictEqual(component.description.text, 'program-year objective 0');
+    assert.strictEqual(component.description.fadeText.displayText.text, 'program-year objective 0');
     await component.description.openEditor();
     await component.description.edit(newDescription);
     await component.description.save();
-    assert.strictEqual(component.description.text, newDescription);
+    assert.strictEqual(component.description.fadeText.displayText.text, newDescription);
   });
 
   test('can manage competency', async function (assert) {

--- a/packages/frontend/tests/integration/components/program-year/objective-list-test.gjs
+++ b/packages/frontend/tests/integration/components/program-year/objective-list-test.gjs
@@ -45,7 +45,10 @@ module('Integration | Component | program-year/objective-list', function (hooks)
     assert.strictEqual(component.headers[4].text, 'Actions');
 
     assert.strictEqual(component.objectives.length, 2);
-    assert.strictEqual(component.objectives[0].description.text, 'Objective B');
+    assert.strictEqual(
+      component.objectives[0].description.fadeText.displayText.text,
+      'Objective B',
+    );
     assert.strictEqual(
       component.objectives[0].selectedTerms.list[0].title,
       'Vocabulary 1 (school 0)',
@@ -54,7 +57,10 @@ module('Integration | Component | program-year/objective-list', function (hooks)
       component.objectives[0].selectedTerms.list[0].terms[0].name,
       'term 1 (inactive)',
     );
-    assert.strictEqual(component.objectives[1].description.text, 'Objective A');
+    assert.strictEqual(
+      component.objectives[1].description.fadeText.displayText.text,
+      'Objective A',
+    );
     assert.strictEqual(
       component.objectives[1].selectedTerms.list[0].title,
       'Vocabulary 1 (school 0)',

--- a/packages/frontend/tests/integration/components/program-year/objectives-test.gjs
+++ b/packages/frontend/tests/integration/components/program-year/objectives-test.gjs
@@ -41,7 +41,7 @@ module('Integration | Component | program-year/objectives', function (hooks) {
 
     assert.strictEqual(component.objectiveList.objectives.length, 2);
     assert.strictEqual(
-      component.objectiveList.objectives[0].description.text,
+      component.objectiveList.objectives[0].description.fadeText.displayText.text,
       'program-year objective 0',
     );
     assert.ok(component.objectiveList.objectives[0].competency.hasCompetency);
@@ -56,7 +56,7 @@ module('Integration | Component | program-year/objectives', function (hooks) {
     assert.ok(component.objectiveList.objectives[0].meshDescriptors.isEmpty);
 
     assert.strictEqual(
-      component.objectiveList.objectives[1].description.text,
+      component.objectiveList.objectives[1].description.fadeText.displayText.text,
       'program-year objective 1',
     );
     assert.notOk(component.objectiveList.objectives[1].competency.hasCompetency);
@@ -116,7 +116,7 @@ module('Integration | Component | program-year/objectives', function (hooks) {
 
     assert.strictEqual(component.objectiveList.objectives.length, 1);
     assert.strictEqual(
-      component.objectiveList.objectives[0].description.text,
+      component.objectiveList.objectives[0].description.fadeText.displayText.text,
       'program-year objective 0',
     );
     assert.ok(component.objectiveList.objectives[0].competency.hasCompetency);

--- a/packages/frontend/tests/pages/components/program-year/objective-list-item.js
+++ b/packages/frontend/tests/pages/components/program-year/objective-list-item.js
@@ -4,6 +4,7 @@ import meshManager from './manage-objective-descriptors';
 import competencyManager from './manage-objective-competency';
 import meshDescriptors from './objective-list-item-descriptors';
 import competency from './objective-list-item-competency';
+import fadeText from 'ilios-common/page-objects/components/fade-text';
 import taxonomyManager from 'ilios-common/page-objects/components/taxonomy-manager';
 import selectedTerms from 'ilios-common/page-objects/components/objective-list-item-terms';
 
@@ -13,6 +14,7 @@ const definition = {
   toggleExpandCollapse: clickable('[data-test-toggle-expand]'),
   description: {
     scope: '[data-test-description]',
+    fadeText,
     openEditor: clickable('[data-test-edit]'),
     editorContents: pageObjectQuillEditorValue('[data-test-html-editor]'),
     edit: pageObjectFillInQuillEditor('[data-test-html-editor]'),

--- a/packages/ilios-common/addon-test-support/ilios-common/page-objects/components/editable-text.js
+++ b/packages/ilios-common/addon-test-support/ilios-common/page-objects/components/editable-text.js
@@ -1,4 +1,4 @@
-import { clickable, create, text } from 'ember-cli-page-object';
+import { attribute, clickable, create, text } from 'ember-cli-page-object';
 import fadeText from './fade-text.js';
 
 const definition = {
@@ -10,6 +10,7 @@ const definition = {
   },
   cancel: clickable('[data-test-cancel]'),
   save: clickable('[data-test-save]'),
+  isSaveDisabled: attribute('disabled', '[data-test-save]'),
   fadeText,
 };
 

--- a/packages/ilios-common/addon-test-support/ilios-common/page-objects/components/editable-text.js
+++ b/packages/ilios-common/addon-test-support/ilios-common/page-objects/components/editable-text.js
@@ -1,0 +1,17 @@
+import { clickable, create, text } from 'ember-cli-page-object';
+import fadeText from './fade-text.js';
+
+const definition = {
+  scope: '[data-test-editable-text]',
+  value: text(),
+  editable: {
+    scope: '[data-test-edit]',
+    edit: clickable(),
+  },
+  cancel: clickable('[data-test-cancel]'),
+  save: clickable('[data-test-save]'),
+  fadeText,
+};
+
+export default definition;
+export const component = create(definition);

--- a/packages/ilios-common/addon-test-support/ilios-common/page-objects/components/fade-text.js
+++ b/packages/ilios-common/addon-test-support/ilios-common/page-objects/components/fade-text.js
@@ -4,7 +4,7 @@ const definition = {
   scope: '[data-test-fade-text]',
   enabled: isPresent('[data-test-fade-text-control]'),
   displayText: {
-    scope: '.display-text-wrapper',
+    scope: '[data-test-display-text]',
     isFaded: hasClass('faded'),
   },
   control: {

--- a/packages/ilios-common/addon-test-support/ilios-common/page-objects/components/fade-text.js
+++ b/packages/ilios-common/addon-test-support/ilios-common/page-objects/components/fade-text.js
@@ -1,4 +1,11 @@
-import { attribute, clickable, create, hasClass, isPresent } from 'ember-cli-page-object';
+import {
+  attribute,
+  clickable,
+  collection,
+  create,
+  hasClass,
+  isPresent,
+} from 'ember-cli-page-object';
 
 const definition = {
   scope: '[data-test-fade-text]',
@@ -8,6 +15,11 @@ const definition = {
     isFaded: hasClass('faded'),
   },
   control: {
+    scope: '[data-test-fade-text-controls]',
+    buttons: collection('button', {
+      click: clickable(),
+      title: attribute('title'),
+    }),
     expand: {
       scope: '[data-test-expand]',
       click: clickable(),

--- a/packages/ilios-common/addon-test-support/ilios-common/page-objects/components/session/overview.js
+++ b/packages/ilios-common/addon-test-support/ilios-common/page-objects/components/session/overview.js
@@ -8,6 +8,7 @@ import {
   text,
 } from 'ember-cli-page-object';
 import { pageObjectFillInQuillEditor } from 'ilios-common';
+import fadeText from '../fade-text';
 import postrequisiteEditor from './postrequisite-editor';
 import yesNoToggle from '../toggle-yesno';
 import ilm from './ilm';
@@ -39,8 +40,8 @@ const definition = {
     hasError: isVisible('.validation-error-message'),
   },
   sessionDescription: {
-    scope: '[data-test-description]',
-    value: text('span', { at: 0 }),
+    scope: '[data-test-description] [data-test-editable-text]',
+    fadeText,
     edit: clickable('[data-test-edit]'),
     set: pageObjectFillInQuillEditor('[data-test-html-editor]'),
     save: clickable('.done'),
@@ -49,8 +50,8 @@ const definition = {
     hasError: isVisible('.validation-error-message'),
   },
   instructionalNotes: {
-    scope: '[data-test-instructional-notes]',
-    value: text('span', { at: 0 }),
+    scope: '[data-test-instructional-notes] [data-test-editable-text]',
+    fadeText,
     edit: clickable('[data-test-edit]'),
     set: pageObjectFillInQuillEditor('[data-test-html-editor]'),
     save: clickable('.done'),

--- a/packages/ilios-common/addon/components/course/header.gjs
+++ b/packages/ilios-common/addon/components/course/header.gjs
@@ -56,10 +56,8 @@ export default class CourseHeaderComponent extends Component {
             @value={{this.courseTitle}}
             @save={{perform this.changeTitle}}
             @close={{this.revertTitleChanges}}
-            @saveOnEnter={{true}}
             @onEditingStatusChange={{set this "isEditingTitle"}}
-            @closeOnEscape={{true}}
-            as |isSaving|
+            as |keyboard isSaving|
           >
             <input
               aria-label={{t "general.courseTitle"}}
@@ -68,6 +66,7 @@ export default class CourseHeaderComponent extends Component {
               value={{this.courseTitle}}
               {{on "input" (pick "target.value" (set this "courseTitle"))}}
               {{this.validations.attach "courseTitle"}}
+              {{keyboard}}
             />
             <YupValidationMessage
               @description={{t "general.title"}}

--- a/packages/ilios-common/addon/components/course/header.gjs
+++ b/packages/ilios-common/addon/components/course/header.gjs
@@ -15,6 +15,7 @@ import pick from 'ilios-common/helpers/pick';
 import FaIcon from 'ilios-common/components/fa-icon';
 import PublicationMenu from 'ilios-common/components/course/publication-menu';
 import PublicationStatus from 'ilios-common/components/publication-status';
+import focus from 'ilios-common/modifiers/focus';
 
 export default class CourseHeaderComponent extends Component {
   @service iliosConfig;
@@ -67,6 +68,7 @@ export default class CourseHeaderComponent extends Component {
               {{on "input" (pick "target.value" (set this "courseTitle"))}}
               {{this.validations.attach "courseTitle"}}
               {{keyboard}}
+              {{focus}}
             />
             <YupValidationMessage
               @description={{t "general.title"}}

--- a/packages/ilios-common/addon/components/course/objective-list-item-parents.gjs
+++ b/packages/ilios-common/addon/components/course/objective-list-item-parents.gjs
@@ -4,14 +4,18 @@ import t from 'ember-intl/helpers/t';
 import { on } from '@ember/modifier';
 import FaIcon from 'ilios-common/components/fa-icon';
 import FadeText from 'ilios-common/components/fade-text';
-import onResize from 'ember-on-resize-modifier/modifiers/on-resize';
 
 export default class CourseObjectiveListItemParentsComponent extends Component {
-  get parents() {
+  get parentTitles() {
     return this.args.parents
       .slice()
       .sort(sortableByPosition)
       .map((t) => t.title);
+  }
+
+  get parentsList() {
+    const items = this.parentTitles.map((t) => `<li>${t}</li>`).join('');
+    return `<ul>${items}</ul>`;
   }
   <template>
     <div class="course-objective-list-item-parents grid-item" data-test-objective-list-item-parents>
@@ -42,68 +46,25 @@ export default class CourseObjectiveListItemParentsComponent extends Component {
       {{else}}
         {{#if @parents}}
           <FadeText
-            @text={{this.parents}}
-            @expanded={{@fadeTextExpanded}}
-            @onExpandAll={{@onExpandAllFadeText}}
-            as |displayText expand collapse updateTextDims shouldFade expanded|
+            @text={{this.parentsList}}
+            @forceExpanded={{@fadeTextExpanded}}
+            @setExpanded={{@setFadeTextExpanded}}
+            as |ft|
           >
             {{#if @editable}}
-              <span data-test-parent>
-                <button
-                  type="button"
-                  class="link-button"
-                  title={{t "general.edit"}}
-                  {{on "click" @manage}}
-                  data-test-manage
-                >
-                  <div class="display-text-wrapper{{if shouldFade ' faded'}}">
-                    <div class="display-text" {{onResize updateTextDims}}>
-                      {{displayText}}
-                    </div>
-                  </div>
-                  {{#if @showIcon}}
-                    <FaIcon data-test-edit-icon @icon="pen-to-square" class="enabled" />
-                  {{/if}}
-                </button>
-              </span>
-            {{else}}
-              <span data-test-parent>
-                <div class="display-text-wrapper{{if shouldFade ' faded'}}">
-                  <div class="display-text" {{onResize updateTextDims}}>
-                    {{displayText}}
-                  </div>
-                </div>
-              </span>
-            {{/if}}
-            {{#if shouldFade}}
-              <div
-                class="fade-text-control"
-                data-test-fade-text-control
-                {{! template-lint-disable no-invalid-interactive}}
+              <button
+                type="button"
+                class="link-button"
+                title={{t "general.edit"}}
                 {{on "click" @manage}}
+                data-test-manage
               >
-                <button
-                  class="expand-text-button"
-                  type="button"
-                  title={{t "general.expand"}}
-                  data-test-expand
-                  {{on "click" expand}}
-                >
-                  <FaIcon @icon="angles-down" />
-                </button>
-              </div>
+                {{ft.text}}
+              </button>
+              {{ft.controls}}
             {{else}}
-              {{#if expanded}}
-                <button
-                  class="collapse-text-button"
-                  title={{t "general.collapse"}}
-                  type="button"
-                  data-test-collapse
-                  {{on "click" collapse}}
-                >
-                  <FaIcon @icon="angles-up" />
-                </button>
-              {{/if}}
+              {{ft.text}}
+              {{ft.controls}}
             {{/if}}
           </FadeText>
         {{else}}

--- a/packages/ilios-common/addon/components/course/objective-list-item-parents.gjs
+++ b/packages/ilios-common/addon/components/course/objective-list-item-parents.gjs
@@ -63,7 +63,7 @@ export default class CourseObjectiveListItemParentsComponent extends Component {
               </button>
               {{ft.controls}}
             {{else}}
-              {{ft.text}}
+              {{ft.text preserveLinks=true}}
               {{ft.controls}}
             {{/if}}
           </FadeText>

--- a/packages/ilios-common/addon/components/course/objective-list-item-parents.gjs
+++ b/packages/ilios-common/addon/components/course/objective-list-item-parents.gjs
@@ -45,28 +45,25 @@ export default class CourseObjectiveListItemParentsComponent extends Component {
         </button>
       {{else}}
         {{#if @parents}}
-          <FadeText
-            @text={{this.parentsList}}
-            @forceExpanded={{@fadeTextExpanded}}
-            @setExpanded={{@setFadeTextExpanded}}
-            as |ft|
-          >
-            {{#if @editable}}
-              <button
-                type="button"
-                class="link-button"
-                title={{t "general.edit"}}
-                {{on "click" @manage}}
-                data-test-manage
-              >
-                {{ft.text}}
-              </button>
-              {{ft.controls}}
-            {{else}}
-              {{ft.text preserveLinks=true}}
-              {{ft.controls}}
-            {{/if}}
-          </FadeText>
+          {{#if @editable}}
+            <FadeText
+              @text={{this.parentsList}}
+              @forceExpanded={{@fadeTextExpanded}}
+              @setExpanded={{@setFadeTextExpanded}}
+            >
+              <:additionalControls>
+                <button class="edit" data-test-manage type="button" {{on "click" @manage}}>
+                  {{t "general.edit"}}
+                </button>
+              </:additionalControls>
+            </FadeText>
+          {{else}}
+            <FadeText
+              @text={{this.parentsList}}
+              @forceExpanded={{@fadeTextExpanded}}
+              @setExpanded={{@setFadeTextExpanded}}
+            />
+          {{/if}}
         {{else}}
           {{#if @editable}}
             <button type="button" {{on "click" @manage}} data-test-manage>

--- a/packages/ilios-common/addon/components/course/objective-list-item.gjs
+++ b/packages/ilios-common/addon/components/course/objective-list-item.gjs
@@ -239,7 +239,7 @@ export default class CourseObjectiveListItemComponent extends Component {
               </:postValue>
             </EditableField>
           {{else}}
-            {{ft.text}}
+            {{ft.text preserveLinks=true}}
             {{ft.controls}}
           {{/if}}
         </FadeText>

--- a/packages/ilios-common/addon/components/course/objective-list-item.gjs
+++ b/packages/ilios-common/addon/components/course/objective-list-item.gjs
@@ -142,10 +142,6 @@ export default class CourseObjectiveListItemComponent extends Component {
   });
 
   @action
-  expandAllFadeText(isExpanded) {
-    this.fadeTextExpanded = isExpanded;
-  }
-  @action
   revertDescriptionChanges() {
     this.description = this.args.courseObjective.title;
     this.validations.addErrorDisplayFor('descriptionWithoutMarkup');
@@ -211,41 +207,42 @@ export default class CourseObjectiveListItemComponent extends Component {
       data-test-course-objective-list-item
     >
       <div class="description grid-item" data-test-description>
-        {{#if (and @editable (not this.isManaging) (not this.showRemoveConfirmation))}}
-          <EditableField
-            @value={{this.description}}
-            @renderHtml={{true}}
-            @save={{perform this.saveDescriptionChanges}}
-            @close={{this.revertDescriptionChanges}}
-            @showTitle={{true}}
-          >
-            <:default>
-              <HtmlEditor
-                @content={{this.description}}
-                @update={{this.changeDescription}}
-                @autofocus={{true}}
-              />
-              <YupValidationMessage
-                @description={{t "general.description"}}
-                @validationErrors={{this.validations.errors.descriptionWithoutMarkup}}
-                data-test-description-validation-error-message
-              />
-            </:default>
-            <:value>
-              <FadeText
-                @expanded={{this.fadeTextExpanded}}
-                @onExpandAll={{this.expandAllFadeText}}
-                @text={{this.description}}
-              />
-            </:value>
-          </EditableField>
-        {{else}}
-          <FadeText
-            @text={{@courseObjective.title}}
-            @expanded={{this.fadeTextExpanded}}
-            @onExpandAll={{this.expandAllFadeText}}
-          />
-        {{/if}}
+        <FadeText
+          @forceExpanded={{this.fadeTextExpanded}}
+          @setExpanded={{set this "fadeTextExpanded"}}
+          @text={{this.description}}
+          as |ft|
+        >
+          {{#if (and @editable (not this.isManaging) (not this.showRemoveConfirmation))}}
+            <EditableField
+              @value={{this.description}}
+              @save={{perform this.saveDescriptionChanges}}
+              @close={{this.revertDescriptionChanges}}
+            >
+              <:default>
+                <HtmlEditor
+                  @content={{this.description}}
+                  @update={{this.changeDescription}}
+                  @autofocus={{true}}
+                />
+                <YupValidationMessage
+                  @description={{t "general.description"}}
+                  @validationErrors={{this.validations.errors.descriptionWithoutMarkup}}
+                  data-test-description-validation-error-message
+                />
+              </:default>
+              <:value>
+                {{ft.text}}
+              </:value>
+              <:postValue>
+                {{ft.controls}}
+              </:postValue>
+            </EditableField>
+          {{else}}
+            {{ft.text}}
+            {{ft.controls}}
+          {{/if}}
+        </FadeText>
       </div>
       <ObjectiveListItemParents
         @parents={{this.parents}}
@@ -256,7 +253,7 @@ export default class CourseObjectiveListItemComponent extends Component {
         @isSaving={{this.saveParents.isRunning}}
         @cancel={{this.cancel}}
         @fadeTextExpanded={{this.fadeTextExpanded}}
-        @onExpandAllFadeText={{this.expandAllFadeText}}
+        @setFadeTextExpanded={{set this "fadeTextExpanded"}}
       />
 
       <ObjectiveListItemTerms

--- a/packages/ilios-common/addon/components/course/objective-list-item.gjs
+++ b/packages/ilios-common/addon/components/course/objective-list-item.gjs
@@ -7,7 +7,7 @@ import { findById, mapBy } from 'ilios-common/utils/array-helpers';
 import { TrackedAsyncData } from 'ember-async-data';
 import and from 'ember-truth-helpers/helpers/and';
 import not from 'ember-truth-helpers/helpers/not';
-import EditableField from 'ilios-common/components/editable-field';
+import EditableText from 'ilios-common/components/editable-text';
 import perform from 'ember-concurrency/helpers/perform';
 import HtmlEditor from 'ilios-common/components/html-editor';
 import FadeText from 'ilios-common/components/fade-text';
@@ -39,6 +39,7 @@ export default class CourseObjectiveListItemComponent extends Component {
   @tracked termsBuffer = [];
   @tracked selectedVocabulary;
   @tracked fadeTextExpanded = this.args.printable ?? false;
+  @tracked isEditing = false;
 
   constructor() {
     super(...arguments);
@@ -84,6 +85,7 @@ export default class CourseObjectiveListItemComponent extends Component {
     this.validations.removeErrorDisplayFor('descriptionWithoutMarkup');
     this.args.courseObjective.set('title', this.description);
     await this.args.courseObjective.save();
+    this.isEditing = false;
   });
 
   manageParents = task({ drop: true }, async () => {
@@ -145,6 +147,7 @@ export default class CourseObjectiveListItemComponent extends Component {
   revertDescriptionChanges() {
     this.description = this.args.courseObjective.title;
     this.validations.addErrorDisplayFor('descriptionWithoutMarkup');
+    this.isEditing = false;
   }
   @action
   changeDescription(contents) {
@@ -207,42 +210,51 @@ export default class CourseObjectiveListItemComponent extends Component {
       data-test-course-objective-list-item
     >
       <div class="description grid-item" data-test-description>
-        <FadeText
-          @forceExpanded={{this.fadeTextExpanded}}
-          @setExpanded={{set this "fadeTextExpanded"}}
-          @text={{this.description}}
-          as |ft|
-        >
-          {{#if (and @editable (not this.isManaging) (not this.showRemoveConfirmation))}}
-            <EditableField
-              @value={{this.description}}
-              @save={{perform this.saveDescriptionChanges}}
-              @close={{this.revertDescriptionChanges}}
-            >
-              <:default>
-                <HtmlEditor
-                  @content={{this.description}}
-                  @update={{this.changeDescription}}
-                  @autofocus={{true}}
-                />
-                <YupValidationMessage
-                  @description={{t "general.description"}}
-                  @validationErrors={{this.validations.errors.descriptionWithoutMarkup}}
-                  data-test-description-validation-error-message
-                />
-              </:default>
-              <:value>
-                {{ft.text}}
-              </:value>
-              <:postValue>
-                {{ft.controls}}
-              </:postValue>
-            </EditableField>
-          {{else}}
-            {{ft.text preserveLinks=true}}
-            {{ft.controls}}
-          {{/if}}
-        </FadeText>
+        {{#if (and @editable (not this.isManaging) (not this.showRemoveConfirmation))}}
+          <EditableText
+            @value={{this.description}}
+            @save={{perform this.saveDescriptionChanges}}
+            @close={{this.revertDescriptionChanges}}
+            @isEditing={{this.isEditing}}
+          >
+            <:default>
+              <HtmlEditor
+                @content={{this.description}}
+                @update={{this.changeDescription}}
+                @autofocus={{true}}
+              />
+              <YupValidationMessage
+                @description={{t "general.description"}}
+                @validationErrors={{this.validations.errors.descriptionWithoutMarkup}}
+                data-test-description-validation-error-message
+              />
+            </:default>
+            <:value>
+              <FadeText
+                @forceExpanded={{this.fadeTextExpanded}}
+                @setExpanded={{set this "fadeTextExpanded"}}
+                @text={{this.description}}
+              >
+                <:additionalControls>
+                  <button
+                    class="edit"
+                    data-test-edit
+                    type="button"
+                    {{on "click" (set this "isEditing")}}
+                  >
+                    {{t "general.edit"}}
+                  </button>
+                </:additionalControls>
+              </FadeText>
+            </:value>
+          </EditableText>
+        {{else}}
+          <FadeText
+            @forceExpanded={{this.fadeTextExpanded}}
+            @setExpanded={{set this "fadeTextExpanded"}}
+            @text={{this.description}}
+          />
+        {{/if}}
       </div>
       <ObjectiveListItemParents
         @parents={{this.parents}}

--- a/packages/ilios-common/addon/components/course/objective-list-item.gjs
+++ b/packages/ilios-common/addon/components/course/objective-list-item.gjs
@@ -217,20 +217,27 @@ export default class CourseObjectiveListItemComponent extends Component {
             @renderHtml={{true}}
             @save={{perform this.saveDescriptionChanges}}
             @close={{this.revertDescriptionChanges}}
-            @fadeTextExpanded={{this.fadeTextExpanded}}
-            @onExpandAllFadeText={{this.expandAllFadeText}}
             @showTitle={{true}}
           >
-            <HtmlEditor
-              @content={{this.description}}
-              @update={{this.changeDescription}}
-              @autofocus={{true}}
-            />
-            <YupValidationMessage
-              @description={{t "general.description"}}
-              @validationErrors={{this.validations.errors.descriptionWithoutMarkup}}
-              data-test-description-validation-error-message
-            />
+            <:default>
+              <HtmlEditor
+                @content={{this.description}}
+                @update={{this.changeDescription}}
+                @autofocus={{true}}
+              />
+              <YupValidationMessage
+                @description={{t "general.description"}}
+                @validationErrors={{this.validations.errors.descriptionWithoutMarkup}}
+                data-test-description-validation-error-message
+              />
+            </:default>
+            <:value>
+              <FadeText
+                @expanded={{this.fadeTextExpanded}}
+                @onExpandAll={{this.expandAllFadeText}}
+                @text={{this.description}}
+              />
+            </:value>
           </EditableField>
         {{else}}
           <FadeText

--- a/packages/ilios-common/addon/components/course/overview.gjs
+++ b/packages/ilios-common/addon/components/course/overview.gjs
@@ -281,9 +281,7 @@ export default class CourseOverview extends Component {
                   @value={{if this.externalId this.externalId (t "general.clickToEdit")}}
                   @save={{perform this.changeExternalId}}
                   @close={{this.revertExternalIdChanges}}
-                  @saveOnEnter={{true}}
-                  @closeOnEscape={{true}}
-                  as |isSaving|
+                  as |keyboard isSaving|
                 >
                   <input
                     id="external-id-{{templateId}}"
@@ -292,6 +290,7 @@ export default class CourseOverview extends Component {
                     value={{this.externalId}}
                     {{on "input" (pick "target.value" (set this "externalId"))}}
                     {{this.validations.attach "externalId"}}
+                    {{keyboard}}
                   />
                   <YupValidationMessage
                     @description={{t "general.externalId"}}

--- a/packages/ilios-common/addon/components/course/overview.gjs
+++ b/packages/ilios-common/addon/components/course/overview.gjs
@@ -24,6 +24,7 @@ import eq from 'ember-truth-helpers/helpers/eq';
 import formatDate from 'ember-intl/helpers/format-date';
 import DatePicker from 'ilios-common/components/date-picker';
 import pipe from 'ilios-common/helpers/pipe';
+import focus from 'ilios-common/modifiers/focus';
 
 export default class CourseOverview extends Component {
   @service currentUser;
@@ -291,6 +292,7 @@ export default class CourseOverview extends Component {
                     {{on "input" (pick "target.value" (set this "externalId"))}}
                     {{this.validations.attach "externalId"}}
                     {{keyboard}}
+                    {{focus}}
                   />
                   <YupValidationMessage
                     @description={{t "general.externalId"}}
@@ -314,6 +316,7 @@ export default class CourseOverview extends Component {
                   <select
                     id="clerkship-type-{{templateId}}"
                     {{on "change" this.setCourseClerkshipType}}
+                    {{focus}}
                   >
                     <option value="null" selected={{isEmpty this.selectedClerkshipType}}>
                       {{t "general.notAClerkship"}}
@@ -355,6 +358,7 @@ export default class CourseOverview extends Component {
                       (set this "startDate")
                       (fn this.validations.addErrorDisplayFor "startDate")
                     }}
+                    @autofocus={{true}}
                   />
                 </EditableField>
                 <YupValidationMessage
@@ -381,6 +385,7 @@ export default class CourseOverview extends Component {
                       (set this "endDate")
                       (fn this.validations.addErrorDisplayFor "endDate")
                     }}
+                    @autofocus={{true}}
                   />
                 </EditableField>
                 <YupValidationMessage
@@ -401,7 +406,7 @@ export default class CourseOverview extends Component {
                   @save={{this.changeLevel}}
                   @close={{this.revertLevelChanges}}
                 >
-                  <select id="level-{{templateId}}" {{on "change" this.setLevel}}>
+                  <select id="level-{{templateId}}" {{on "change" this.setLevel}} {{focus}}>
                     {{#each this.levelOptions as |levelOption|}}
                       <option value={{levelOption}} selected={{eq levelOption this.level}}>
                         {{levelOption}}

--- a/packages/ilios-common/addon/components/date-picker.gjs
+++ b/packages/ilios-common/addon/components/date-picker.gjs
@@ -2,6 +2,7 @@ import Component from '@glimmer/component';
 import { service } from '@ember/service';
 import t from 'ember-intl/helpers/t';
 import datePicker from 'ilios-common/modifiers/date-picker';
+import focus from 'ilios-common/modifiers/focus';
 
 export default class DatePickerComponent extends Component {
   @service intl;
@@ -18,6 +19,7 @@ export default class DatePickerComponent extends Component {
         locale=this.intl.primaryLocale
         onChangeHandler=@onChange
       }}
+      {{focus @autofocus}}
       ...attributes
     />
   </template>

--- a/packages/ilios-common/addon/components/editable-field.gjs
+++ b/packages/ilios-common/addon/components/editable-field.gjs
@@ -26,16 +26,6 @@ export default class EditableFieldComponent extends Component {
     this.setIsEditing(false);
   });
 
-  focusFirstControl = modifier((element) => {
-    const elements = element.querySelectorAll('input,textarea,select,.fr-element');
-    if (elements.length) {
-      const visibleControls = Array.from(elements).filter((el) => {
-        return !el.hidden;
-      });
-      visibleControls[0].focus();
-    }
-  });
-
   /*
    * Modifier we can attach to the editable field elemnts so we can handle saving and closing via enter and escape
    */
@@ -69,7 +59,7 @@ export default class EditableFieldComponent extends Component {
     >
       <span class="content">
         {{#if this.isEditing}}
-          <span class="editor" {{this.focusFirstControl}}>
+          <span class="editor">
             {{yield
               this.keyboard
               this.saveData.isRunning

--- a/packages/ilios-common/addon/components/editable-field.gjs
+++ b/packages/ilios-common/addon/components/editable-field.gjs
@@ -12,6 +12,15 @@ import { fn } from '@ember/helper';
 export default class EditableFieldComponent extends Component {
   @tracked isEditing = false;
 
+  get hasVisibleValue() {
+    const value = this.args.value || '';
+    const text = value.toString();
+    const noTagsText = text.replace(/(<([^>]+)>)/gi, '');
+    const strippedText = noTagsText.replace(/&nbsp;/gi, '').replace(/\s/g, '');
+
+    return Boolean(strippedText.length);
+  }
+
   saveData = task({ drop: true }, async () => {
     await timeout(1);
     const result = await this.args.save();
@@ -98,14 +107,18 @@ export default class EditableFieldComponent extends Component {
             type="button"
             {{on "click" (fn this.setIsEditing true)}}
           >
-            {{#if @value}}
+            {{#if this.hasVisibleValue}}
               {{#if (has-block "value")}}
                 {{yield to="value"}}
               {{else}}
                 {{@value}}
               {{/if}}
             {{else}}
-              {{@clickPrompt}}
+              {{#if @clickPrompt}}
+                {{@clickPrompt}}
+              {{else}}
+                <FaIcon @icon="pen-to-square" />
+              {{/if}}
             {{/if}}
           </button>
           {{yield to="postValue"}}

--- a/packages/ilios-common/addon/components/editable-field.gjs
+++ b/packages/ilios-common/addon/components/editable-field.gjs
@@ -118,6 +118,7 @@ export default class EditableFieldComponent extends Component {
               {{@clickPrompt}}
             {{/if}}
           </button>
+          {{yield to="postValue"}}
         {{/if}}
       </span>
     </div>

--- a/packages/ilios-common/addon/components/editable-field.gjs
+++ b/packages/ilios-common/addon/components/editable-field.gjs
@@ -8,20 +8,9 @@ import perform from 'ember-concurrency/helpers/perform';
 import t from 'ember-intl/helpers/t';
 import FaIcon from 'ilios-common/components/fa-icon';
 import { fn } from '@ember/helper';
-import FadeText from 'ilios-common/components/fade-text';
-import onResize from 'ember-on-resize-modifier/modifiers/on-resize';
 
 export default class EditableFieldComponent extends Component {
   @tracked isEditing = false;
-
-  get looksEmpty() {
-    const value = this.args.value || '';
-    const text = value.toString();
-    const noTagsText = text.replace(/(<([^>]+)>)/gi, '');
-    const strippedText = noTagsText.replace(/&nbsp;/gi, '').replace(/\s/g, '');
-
-    return strippedText.length === 0;
-  }
 
   saveData = task({ drop: true }, async () => {
     await timeout(1);
@@ -112,89 +101,25 @@ export default class EditableFieldComponent extends Component {
             </span>
           </span>
         {{else}}
-          <span>
+          <button
+            class="link-button"
+            title={{if @showTitle (t "general.edit")}}
+            data-test-edit
+            type="button"
+            {{on "click" (fn this.setIsEditing true)}}
+          >
             {{#if @value}}
-              {{#if this.looksEmpty}}
-                <button
-                  class="link-button"
-                  type="button"
-                  data-test-edit
-                  {{on "click" (fn this.setIsEditing true)}}
-                >
-                  <FaIcon @icon="pen-to-square" class="enabled" />
-                </button>
+              {{#if (has-block "value")}}
+                {{yield to="value"}}
               {{else}}
-                <FadeText
-                  @text={{@value}}
-                  @onEdit={{fn this.setIsEditing true}}
-                  @expanded={{@fadeTextExpanded}}
-                  @onExpandAll={{@onExpandAllFadeText}}
-                  as |displayText expand collapse updateTextDims shouldFade expanded|
-                >
-                  <button
-                    class="link-button"
-                    title={{if @showTitle (t "general.edit")}}
-                    data-test-edit
-                    type="button"
-                    {{on "click" (fn this.setIsEditing true)}}
-                  >
-                    <div class="display-text-wrapper{{if shouldFade ' faded'}}">
-                      <div class="display-text" {{onResize updateTextDims}}>
-                        {{displayText}}
-                      </div>
-                    </div>
-                    {{#if @showIcon}}
-                      <FaIcon data-test-edit-icon @icon="pen-to-square" class="enabled" />
-                    {{/if}}
-                  </button>
-                  {{#if shouldFade}}
-                    <div
-                      class="fade-text-control"
-                      data-test-fade-text-control
-                      {{! template-lint-disable no-invalid-interactive}}
-                      {{on "click" (fn this.setIsEditing true)}}
-                    >
-                      <button
-                        class="expand-text-button"
-                        type="button"
-                        aria-label={{t "general.expand"}}
-                        title={{t "general.expand"}}
-                        data-test-expand
-                        {{on "click" expand}}
-                      >
-                        <FaIcon @icon="angles-down" />
-                      </button>
-                    </div>
-                  {{else}}
-                    {{#if expanded}}
-                      <button
-                        class="collapse-text-button"
-                        aria-label={{t "general.collapse"}}
-                        title={{t "general.collapse"}}
-                        type="button"
-                        data-test-collapse
-                        {{on "click" collapse}}
-                      >
-                        <FaIcon @icon="angles-up" />
-                      </button>
-                    {{/if}}
-                  {{/if}}
-                </FadeText>
+                {{@value}}
               {{/if}}
             {{else}}
-              <button
-                class="link-button"
-                data-test-edit
-                type="button"
-                {{on "click" (fn this.setIsEditing true)}}
-              >
-                {{@clickPrompt}}
-              </button>
+              {{@clickPrompt}}
             {{/if}}
-          </span>
+          </button>
         {{/if}}
       </span>
-
     </div>
   </template>
 }

--- a/packages/ilios-common/addon/components/editable-text.gjs
+++ b/packages/ilios-common/addon/components/editable-text.gjs
@@ -47,6 +47,7 @@ export default class EditableTextComponent extends Component {
                 type="button"
                 class="done"
                 title={{t "general.save"}}
+                disabled={{@isSaveDisabled}}
                 {{on "click" (perform this.saveData)}}
                 data-test-save
               >

--- a/packages/ilios-common/addon/components/editable-text.gjs
+++ b/packages/ilios-common/addon/components/editable-text.gjs
@@ -1,0 +1,85 @@
+import Component from '@glimmer/component';
+import { task, timeout } from 'ember-concurrency';
+import { on } from '@ember/modifier';
+import { action } from '@ember/object';
+import perform from 'ember-concurrency/helpers/perform';
+import t from 'ember-intl/helpers/t';
+import FaIcon from 'ilios-common/components/fa-icon';
+
+export default class EditableTextComponent extends Component {
+  get hasVisibleValue() {
+    const value = this.args.value || '';
+    const text = value.toString();
+    const noTagsText = text.replace(/(<([^>]+)>)/gi, '');
+    const strippedText = noTagsText.replace(/&nbsp;/gi, '').replace(/\s/g, '');
+
+    return Boolean(strippedText.length);
+  }
+
+  saveData = task({ drop: true }, async () => {
+    await timeout(1);
+    const result = await this.args.save();
+    if (result !== false) {
+      this.args.close(false);
+    }
+  });
+
+  closeEditor = task({ drop: true }, async () => {
+    await timeout(1);
+    await this.args.close();
+  });
+
+  @action
+  edit() {
+    if (this.args.edit) {
+      this.args.edit();
+    }
+  }
+
+  <template>
+    <div class="editable-text" data-test-editable-text ...attributes>
+      <span class="content">
+        {{#if @isEditing}}
+          <span class="editor">
+            {{yield this.saveData.isRunning (perform this.saveData) (perform this.closeEditor)}}
+            <span class="actions">
+              <button
+                type="button"
+                class="done"
+                title={{t "general.save"}}
+                {{on "click" (perform this.saveData)}}
+                data-test-save
+              >
+                <FaIcon
+                  @icon={{if this.saveData.isRunning "spinner" "check"}}
+                  @spin={{this.saveData.isRunning}}
+                />
+              </button>
+              <button
+                class="cancel"
+                type="button"
+                title={{t "general.cancel"}}
+                {{on "click" (perform this.closeEditor)}}
+                data-test-cancel
+              >
+                <FaIcon @icon="xmark" />
+              </button>
+            </span>
+          </span>
+        {{else}}
+          {{#if this.hasVisibleValue}}
+            {{#if (has-block "value")}}
+              {{yield to="value"}}
+            {{else}}
+              {{@value}}
+            {{/if}}
+          {{else}}
+            <button type="button" class="link-button" data-test-edit {{on "click" this.edit}}>
+              {{t "general.clickToEdit"}}
+            </button>
+          {{/if}}
+        {{/if}}
+      </span>
+    </div>
+  </template>
+}

--- a/packages/ilios-common/addon/components/fade-text.gjs
+++ b/packages/ilios-common/addon/components/fade-text.gjs
@@ -57,25 +57,39 @@ export default class FadeTextComponent extends Component {
 
   <template>
     <span class="fade-text" data-test-fade-text ...attributes>
-      {{yield
-        (hash
-          controls=(component
-            controls
-            expandable=this.shouldFade
-            collapsible=this.isExpanded
-            expand=this.expand
-            collapse=this.collapse
+      {{#if (has-block)}}
+        {{yield
+          (hash
+            controls=(component
+              Controls
+              expandable=this.shouldFade
+              collapsible=this.isExpanded
+              expand=this.expand
+              collapse=this.collapse
+            )
+            text=(component
+              FadedText faded=this.shouldFade resize=this.updateTextDims text=this.displayText
+            )
           )
-          text=(component
-            fadedText faded=this.shouldFade resize=this.updateTextDims text=this.displayText
-          )
-        )
-      }}
+        }}
+      {{else}}
+        <FadedText
+          @faded={{this.shouldFade}}
+          @resize={{this.updateTextDims}}
+          @text={{this.displayText}}
+        />
+        <Controls
+          @expandable={{this.shouldFade}}
+          @collapsible={{this.isExpanded}}
+          @expand={{this.expand}}
+          @collapse={{this.collapse}}
+        />
+      {{/if}}
     </span>
   </template>
 }
 
-const controls = <template>
+const Controls = <template>
   {{#if @expandable}}
     <button
       class="expand-text-button"
@@ -103,7 +117,7 @@ const controls = <template>
   {{/if}}
 </template>;
 
-const fadedText = <template>
+const FadedText = <template>
   <div class="display-text-wrapper{{if @faded ' faded'}}">
     <div class="display-text" {{onResize @resize}}>
       {{@text}}

--- a/packages/ilios-common/addon/components/objective-sort-manager.gjs
+++ b/packages/ilios-common/addon/components/objective-sort-manager.gjs
@@ -150,7 +150,7 @@ export default class ObjectiveSortManagerComponent extends Component {
                 <FaIcon @icon="up-down-left-right" />
               {{/unless}}
               <span class="draggable-object-content">
-                <FadeText @text={{item.title}} />
+                <FadeText @text={{item.title}} @preserveLinks={{true}} />
               </span>
             </li>
           {{/each}}

--- a/packages/ilios-common/addon/components/objective-sort-manager.gjs
+++ b/packages/ilios-common/addon/components/objective-sort-manager.gjs
@@ -150,10 +150,7 @@ export default class ObjectiveSortManagerComponent extends Component {
                 <FaIcon @icon="up-down-left-right" />
               {{/unless}}
               <span class="draggable-object-content">
-                <FadeText @text={{item.title}} as |ft|>
-                  {{ft.text}}
-                  {{ft.controls}}
-                </FadeText>
+                <FadeText @text={{item.title}} />
               </span>
             </li>
           {{/each}}

--- a/packages/ilios-common/addon/components/objective-sort-manager.gjs
+++ b/packages/ilios-common/addon/components/objective-sort-manager.gjs
@@ -20,7 +20,6 @@ export default class ObjectiveSortManagerComponent extends Component {
   @tracked draggedAboveItem;
   @tracked draggedBelowItem;
   @tracked sortedItems;
-  @tracked expanded;
 
   @cached
   get objectives() {
@@ -107,11 +106,6 @@ export default class ObjectiveSortManagerComponent extends Component {
       }
     }
   }
-
-  @action
-  toggleExpansion() {
-    this.expanded = !this.expanded;
-  }
   <template>
     <div class="objective-sort-manager">
       <div class="actions">
@@ -156,13 +150,10 @@ export default class ObjectiveSortManagerComponent extends Component {
                 <FaIcon @icon="up-down-left-right" />
               {{/unless}}
               <span class="draggable-object-content">
-                <span>
-                  <FadeText
-                    @text={{item.title}}
-                    @expanded={{this.expanded}}
-                    @onExpandAll={{this.toggleExpansion}}
-                  />
-                </span>
+                <FadeText @text={{item.title}} as |ft|>
+                  {{ft.text}}
+                  {{ft.controls}}
+                </FadeText>
               </span>
             </li>
           {{/each}}

--- a/packages/ilios-common/addon/components/session/header.gjs
+++ b/packages/ilios-common/addon/components/session/header.gjs
@@ -12,6 +12,7 @@ import set from 'ember-set-helper/helpers/set';
 import YupValidationMessage from 'ilios-common/components/yup-validation-message';
 import PublicationMenu from 'ilios-common/components/session/publication-menu';
 import PublicationStatus from 'ilios-common/components/publication-status';
+import focus from 'ilios-common/modifiers/focus';
 
 export default class SessionHeaderComponent extends Component {
   @tracked title;
@@ -58,6 +59,7 @@ export default class SessionHeaderComponent extends Component {
               {{on "input" (pick "target.value" (set this "title"))}}
               {{this.validations.attach "title"}}
               {{keyboard}}
+              {{focus}}
             />
             <YupValidationMessage
               @description={{t "general.title"}}

--- a/packages/ilios-common/addon/components/session/header.gjs
+++ b/packages/ilios-common/addon/components/session/header.gjs
@@ -48,9 +48,7 @@ export default class SessionHeaderComponent extends Component {
             @value={{this.title}}
             @save={{perform this.changeTitle}}
             @close={{this.resetTitle}}
-            @saveOnEnter={{true}}
-            @closeOnEscape={{true}}
-            as |isSaving|
+            as |keyboard isSaving|
           >
             <input
               aria-label={{t "general.title"}}
@@ -59,6 +57,7 @@ export default class SessionHeaderComponent extends Component {
               value={{this.title}}
               {{on "input" (pick "target.value" (set this "title"))}}
               {{this.validations.attach "title"}}
+              {{keyboard}}
             />
             <YupValidationMessage
               @description={{t "general.title"}}

--- a/packages/ilios-common/addon/components/session/ilm.gjs
+++ b/packages/ilios-common/addon/components/session/ilm.gjs
@@ -16,6 +16,7 @@ import pick from 'ilios-common/helpers/pick';
 import set from 'ember-set-helper/helpers/set';
 import YupValidationMessage from 'ilios-common/components/yup-validation-message';
 import SessionOverviewIlmDuedate from 'ilios-common/components/session-overview-ilm-duedate';
+import focus from 'ilios-common/modifiers/focus';
 
 export default class SessionIlmComponent extends Component {
   @service store;
@@ -128,6 +129,7 @@ export default class SessionIlmComponent extends Component {
                 {{this.validations.attach "hours"}}
                 {{on "input" (pick "target.value" (set this "localHours"))}}
                 {{keyboard}}
+                {{focus}}
               />
               <YupValidationMessage
                 @description={{t "general.hours"}}

--- a/packages/ilios-common/addon/components/session/ilm.gjs
+++ b/packages/ilios-common/addon/components/session/ilm.gjs
@@ -118,9 +118,7 @@ export default class SessionIlmComponent extends Component {
               @value={{this.hours}}
               @save={{perform this.changeIlmHours}}
               @close={{this.resetHours}}
-              @saveOnEnter={{true}}
-              @closeOnEscape={{true}}
-              as |isSaving|
+              as |keyboard isSaving|
             >
               <input
                 id="hours-{{this.uniqueId}}"
@@ -129,6 +127,7 @@ export default class SessionIlmComponent extends Component {
                 value={{this.hours}}
                 {{this.validations.attach "hours"}}
                 {{on "input" (pick "target.value" (set this "localHours"))}}
+                {{keyboard}}
               />
               <YupValidationMessage
                 @description={{t "general.hours"}}

--- a/packages/ilios-common/addon/components/session/objective-list-item-parents.gjs
+++ b/packages/ilios-common/addon/components/session/objective-list-item-parents.gjs
@@ -49,28 +49,25 @@ export default class SessionObjectiveListItemParentsComponent extends Component 
         </button>
       {{else}}
         {{#if @parents}}
-          <FadeText
-            @text={{this.parentsList}}
-            @forceExpanded={{@fadeTextExpanded}}
-            @setExpanded={{@setFadeTextExpanded}}
-            as |ft|
-          >
-            {{#if @editable}}
-              <button
-                type="button"
-                class="link-button"
-                title={{t "general.edit"}}
-                {{on "click" @manage}}
-                data-test-manage
-              >
-                {{ft.text}}
-              </button>
-              {{ft.controls}}
-            {{else}}
-              {{ft.text preserveLinks=true}}
-              {{ft.controls}}
-            {{/if}}
-          </FadeText>
+          {{#if @editable}}
+            <FadeText
+              @text={{this.parentsList}}
+              @forceExpanded={{@fadeTextExpanded}}
+              @setExpanded={{@setFadeTextExpanded}}
+            >
+              <:additionalControls>
+                <button class="edit" data-test-manage type="button" {{on "click" @manage}}>
+                  {{t "general.edit"}}
+                </button>
+              </:additionalControls>
+            </FadeText>
+          {{else}}
+            <FadeText
+              @text={{this.parentsList}}
+              @forceExpanded={{@fadeTextExpanded}}
+              @setExpanded={{@setFadeTextExpanded}}
+            />
+          {{/if}}
         {{else}}
           {{#if @editable}}
             <button type="button" {{on "click" @manage}} data-test-manage>

--- a/packages/ilios-common/addon/components/session/objective-list-item-parents.gjs
+++ b/packages/ilios-common/addon/components/session/objective-list-item-parents.gjs
@@ -4,15 +4,20 @@ import t from 'ember-intl/helpers/t';
 import { on } from '@ember/modifier';
 import FaIcon from 'ilios-common/components/fa-icon';
 import FadeText from 'ilios-common/components/fade-text';
-import onResize from 'ember-on-resize-modifier/modifiers/on-resize';
 
 export default class SessionObjectiveListItemParentsComponent extends Component {
-  get parents() {
+  get parentTitles() {
     return this.args.parents
       .slice()
       .sort(sortableByPosition)
       .map((t) => t.title);
   }
+
+  get parentsList() {
+    const items = this.parentTitles.map((t) => `<li>${t}</li>`).join('');
+    return `<ul>${items}</ul>`;
+  }
+
   <template>
     <div
       class="session-objective-list-item-parents grid-item"
@@ -45,68 +50,25 @@ export default class SessionObjectiveListItemParentsComponent extends Component 
       {{else}}
         {{#if @parents}}
           <FadeText
-            @text={{this.parents}}
-            @expanded={{@fadeTextExpanded}}
-            @onExpandAll={{@onExpandAllFadeText}}
-            as |displayText expand collapse updateTextDims shouldFade expanded|
+            @text={{this.parentsList}}
+            @forceExpanded={{@fadeTextExpanded}}
+            @setExpanded={{@setFadeTextExpanded}}
+            as |ft|
           >
             {{#if @editable}}
-              <span data-test-parent>
-                <button
-                  type="button"
-                  class="link-button"
-                  title={{t "general.edit"}}
-                  {{on "click" @manage}}
-                  data-test-manage
-                >
-                  <div class="display-text-wrapper{{if shouldFade ' faded'}}">
-                    <div class="display-text" {{onResize updateTextDims}}>
-                      {{displayText}}
-                    </div>
-                  </div>
-                  {{#if @showIcon}}
-                    <FaIcon data-test-edit-icon @icon="pen-to-square" class="enabled" />
-                  {{/if}}
-                </button>
-              </span>
-            {{else}}
-              <span data-test-parent>
-                <div class="display-text-wrapper{{if shouldFade ' faded'}}">
-                  <div class="display-text" {{onResize updateTextDims}}>
-                    {{displayText}}
-                  </div>
-                </div>
-              </span>
-            {{/if}}
-            {{#if shouldFade}}
-              <div
-                class="fade-text-control"
-                data-test-fade-text-control
-                {{! template-lint-disable no-invalid-interactive}}
+              <button
+                type="button"
+                class="link-button"
+                title={{t "general.edit"}}
                 {{on "click" @manage}}
+                data-test-manage
               >
-                <button
-                  class="expand-text-button"
-                  type="button"
-                  title={{t "general.expand"}}
-                  data-test-expand
-                  {{on "click" expand}}
-                >
-                  <FaIcon @icon="angles-down" />
-                </button>
-              </div>
+                {{ft.text}}
+              </button>
+              {{ft.controls}}
             {{else}}
-              {{#if expanded}}
-                <button
-                  class="collapse-text-button"
-                  title={{t "general.collapse"}}
-                  type="button"
-                  data-test-collapse
-                  {{on "click" collapse}}
-                >
-                  <FaIcon @icon="angles-up" />
-                </button>
-              {{/if}}
+              {{ft.text}}
+              {{ft.controls}}
             {{/if}}
           </FadeText>
         {{else}}

--- a/packages/ilios-common/addon/components/session/objective-list-item-parents.gjs
+++ b/packages/ilios-common/addon/components/session/objective-list-item-parents.gjs
@@ -67,7 +67,7 @@ export default class SessionObjectiveListItemParentsComponent extends Component 
               </button>
               {{ft.controls}}
             {{else}}
-              {{ft.text}}
+              {{ft.text preserveLinks=true}}
               {{ft.controls}}
             {{/if}}
           </FadeText>

--- a/packages/ilios-common/addon/components/session/objective-list-item.gjs
+++ b/packages/ilios-common/addon/components/session/objective-list-item.gjs
@@ -6,7 +6,7 @@ import { service } from '@ember/service';
 import { TrackedAsyncData } from 'ember-async-data';
 import and from 'ember-truth-helpers/helpers/and';
 import not from 'ember-truth-helpers/helpers/not';
-import EditableField from 'ilios-common/components/editable-field';
+import EditableText from 'ilios-common/components/editable-text';
 import perform from 'ember-concurrency/helpers/perform';
 import HtmlEditor from 'ilios-common/components/html-editor';
 import FadeText from 'ilios-common/components/fade-text';
@@ -38,6 +38,7 @@ export default class SessionObjectiveListItemComponent extends Component {
   @tracked termsBuffer = [];
   @tracked selectedVocabulary;
   @tracked fadeTextExpanded = false;
+  @tracked isEditing = false;
 
   constructor() {
     super(...arguments);
@@ -83,6 +84,7 @@ export default class SessionObjectiveListItemComponent extends Component {
     this.validations.removeErrorDisplayFor('descriptionWithoutMarkup');
     this.args.sessionObjective.set('title', this.description);
     await this.args.sessionObjective.save();
+    this.isEditing = false;
   });
 
   manageParents = task({ drop: true }, async () => {
@@ -136,6 +138,7 @@ export default class SessionObjectiveListItemComponent extends Component {
   revertDescriptionChanges() {
     this.description = this.args.sessionObjective.title;
     this.validations.addErrorDisplayFor('descriptionWithoutMarkup');
+    this.isEditing = false;
   }
   @action
   changeDescription(contents) {
@@ -190,42 +193,51 @@ export default class SessionObjectiveListItemComponent extends Component {
       data-test-session-objective-list-item
     >
       <div class="description grid-item" data-test-description>
-        <FadeText
-          @forceExpanded={{this.fadeTextExpanded}}
-          @setExpanded={{set this "fadeTextExpanded"}}
-          @text={{this.description}}
-          as |ft|
-        >
-          {{#if (and @editable (not this.isManaging) (not this.showRemoveConfirmation))}}
-            <EditableField
-              @value={{this.description}}
-              @save={{perform this.saveDescriptionChanges}}
-              @close={{this.revertDescriptionChanges}}
-            >
-              <:default>
-                <HtmlEditor
-                  @content={{this.description}}
-                  @update={{this.changeDescription}}
-                  @autofocus={{true}}
-                />
-                <YupValidationMessage
-                  @description={{t "general.description"}}
-                  @validationErrors={{this.validations.errors.descriptionWithoutMarkup}}
-                  data-test-description-validation-error-message
-                />
-              </:default>
-              <:value>
-                {{ft.text}}
-              </:value>
-              <:postValue>
-                {{ft.controls}}
-              </:postValue>
-            </EditableField>
-          {{else}}
-            {{ft.text preserveLinks=true}}
-            {{ft.controls}}
-          {{/if}}
-        </FadeText>
+        {{#if (and @editable (not this.isManaging) (not this.showRemoveConfirmation))}}
+          <EditableText
+            @value={{this.description}}
+            @save={{perform this.saveDescriptionChanges}}
+            @close={{this.revertDescriptionChanges}}
+            @isEditing={{this.isEditing}}
+          >
+            <:default>
+              <HtmlEditor
+                @content={{this.description}}
+                @update={{this.changeDescription}}
+                @autofocus={{true}}
+              />
+              <YupValidationMessage
+                @description={{t "general.description"}}
+                @validationErrors={{this.validations.errors.descriptionWithoutMarkup}}
+                data-test-description-validation-error-message
+              />
+            </:default>
+            <:value>
+              <FadeText
+                @forceExpanded={{this.fadeTextExpanded}}
+                @setExpanded={{set this "fadeTextExpanded"}}
+                @text={{this.description}}
+              >
+                <:additionalControls>
+                  <button
+                    class="edit"
+                    data-test-edit
+                    type="button"
+                    {{on "click" (set this "isEditing")}}
+                  >
+                    {{t "general.edit"}}
+                  </button>
+                </:additionalControls>
+              </FadeText>
+            </:value>
+          </EditableText>
+        {{else}}
+          <FadeText
+            @forceExpanded={{this.fadeTextExpanded}}
+            @setExpanded={{set this "fadeTextExpanded"}}
+            @text={{this.description}}
+          />
+        {{/if}}
       </div>
       <ObjectiveListItemParents
         @parents={{this.parents}}

--- a/packages/ilios-common/addon/components/session/objective-list-item.gjs
+++ b/packages/ilios-common/addon/components/session/objective-list-item.gjs
@@ -222,7 +222,7 @@ export default class SessionObjectiveListItemComponent extends Component {
               </:postValue>
             </EditableField>
           {{else}}
-            {{ft.text}}
+            {{ft.text preserveLinks=true}}
             {{ft.controls}}
           {{/if}}
         </FadeText>

--- a/packages/ilios-common/addon/components/session/objective-list-item.gjs
+++ b/packages/ilios-common/addon/components/session/objective-list-item.gjs
@@ -200,20 +200,27 @@ export default class SessionObjectiveListItemComponent extends Component {
             @renderHtml={{true}}
             @save={{perform this.saveDescriptionChanges}}
             @close={{this.revertDescriptionChanges}}
-            @fadeTextExpanded={{this.fadeTextExpanded}}
-            @onExpandAllFadeText={{this.expandAllFadeText}}
             @showTitle={{true}}
           >
-            <HtmlEditor
-              @content={{this.description}}
-              @update={{this.changeDescription}}
-              @autofocus={{true}}
-            />
-            <YupValidationMessage
-              @description={{t "general.description"}}
-              @validationErrors={{this.validations.errors.descriptionWithoutMarkup}}
-              data-test-description-validation-error-message
-            />
+            <:default>
+              <HtmlEditor
+                @content={{this.description}}
+                @update={{this.changeDescription}}
+                @autofocus={{true}}
+              />
+              <YupValidationMessage
+                @description={{t "general.description"}}
+                @validationErrors={{this.validations.errors.descriptionWithoutMarkup}}
+                data-test-description-validation-error-message
+              />
+            </:default>
+            <:value>
+              <FadeText
+                @expanded={{this.fadeTextExpanded}}
+                @onExpandAll={{this.expandAllFadeText}}
+                @text={{this.description}}
+              />
+            </:value>
           </EditableField>
         {{else}}
           <FadeText

--- a/packages/ilios-common/addon/components/session/objective-list-item.gjs
+++ b/packages/ilios-common/addon/components/session/objective-list-item.gjs
@@ -133,10 +133,6 @@ export default class SessionObjectiveListItemComponent extends Component {
   });
 
   @action
-  expandAllFadeText(isExpanded) {
-    this.fadeTextExpanded = isExpanded;
-  }
-  @action
   revertDescriptionChanges() {
     this.description = this.args.sessionObjective.title;
     this.validations.addErrorDisplayFor('descriptionWithoutMarkup');
@@ -194,41 +190,42 @@ export default class SessionObjectiveListItemComponent extends Component {
       data-test-session-objective-list-item
     >
       <div class="description grid-item" data-test-description>
-        {{#if (and @editable (not this.isManaging) (not this.showRemoveConfirmation))}}
-          <EditableField
-            @value={{this.description}}
-            @renderHtml={{true}}
-            @save={{perform this.saveDescriptionChanges}}
-            @close={{this.revertDescriptionChanges}}
-            @showTitle={{true}}
-          >
-            <:default>
-              <HtmlEditor
-                @content={{this.description}}
-                @update={{this.changeDescription}}
-                @autofocus={{true}}
-              />
-              <YupValidationMessage
-                @description={{t "general.description"}}
-                @validationErrors={{this.validations.errors.descriptionWithoutMarkup}}
-                data-test-description-validation-error-message
-              />
-            </:default>
-            <:value>
-              <FadeText
-                @expanded={{this.fadeTextExpanded}}
-                @onExpandAll={{this.expandAllFadeText}}
-                @text={{this.description}}
-              />
-            </:value>
-          </EditableField>
-        {{else}}
-          <FadeText
-            @text={{@sessionObjective.title}}
-            @expanded={{this.fadeTextExpanded}}
-            @onExpandAll={{this.expandAllFadeText}}
-          />
-        {{/if}}
+        <FadeText
+          @forceExpanded={{this.fadeTextExpanded}}
+          @setExpanded={{set this "fadeTextExpanded"}}
+          @text={{this.description}}
+          as |ft|
+        >
+          {{#if (and @editable (not this.isManaging) (not this.showRemoveConfirmation))}}
+            <EditableField
+              @value={{this.description}}
+              @save={{perform this.saveDescriptionChanges}}
+              @close={{this.revertDescriptionChanges}}
+            >
+              <:default>
+                <HtmlEditor
+                  @content={{this.description}}
+                  @update={{this.changeDescription}}
+                  @autofocus={{true}}
+                />
+                <YupValidationMessage
+                  @description={{t "general.description"}}
+                  @validationErrors={{this.validations.errors.descriptionWithoutMarkup}}
+                  data-test-description-validation-error-message
+                />
+              </:default>
+              <:value>
+                {{ft.text}}
+              </:value>
+              <:postValue>
+                {{ft.controls}}
+              </:postValue>
+            </EditableField>
+          {{else}}
+            {{ft.text}}
+            {{ft.controls}}
+          {{/if}}
+        </FadeText>
       </div>
       <ObjectiveListItemParents
         @parents={{this.parents}}
@@ -239,7 +236,7 @@ export default class SessionObjectiveListItemComponent extends Component {
         @isSaving={{this.saveParents.isRunning}}
         @cancel={{this.cancel}}
         @fadeTextExpanded={{this.fadeTextExpanded}}
-        @onExpandAllFadeText={{this.expandAllFadeText}}
+        @setFadeTextExpanded={{set this "fadeTextExpanded"}}
       />
 
       <ObjectiveListItemTerms

--- a/packages/ilios-common/addon/components/session/overview.gjs
+++ b/packages/ilios-common/addon/components/session/overview.gjs
@@ -15,6 +15,7 @@ import t from 'ember-intl/helpers/t';
 import formatDate from 'ember-intl/helpers/format-date';
 import { LinkTo } from '@ember/routing';
 import EditableField from 'ilios-common/components/editable-field';
+import EditableText from 'ilios-common/components/editable-text';
 import { on } from '@ember/modifier';
 import eq from 'ember-truth-helpers/helpers/eq';
 import ToggleYesno from 'ilios-common/components/toggle-yesno';
@@ -30,6 +31,7 @@ import join from 'ilios-common/helpers/join';
 import mapBy from 'ilios-common/helpers/map-by';
 import FadeText from 'ilios-common/components/fade-text';
 import focus from 'ilios-common/modifiers/focus';
+import set from 'ember-set-helper/helpers/set';
 
 export default class SessionOverview extends Component {
   @service currentUser;
@@ -42,6 +44,9 @@ export default class SessionOverview extends Component {
   @tracked localDescription;
   @tracked localSessionType;
   @tracked isEditingPostRequisite = false;
+  @tracked isEditingDescription = false;
+  @tracked isEditingInstructionalNotes = false;
+
   @tracked descriptionFadeTextExpanded = false;
   @tracked notesFadeTextExpanded = false;
 
@@ -273,6 +278,7 @@ export default class SessionOverview extends Component {
   @action
   revertInstructionalNotesChanges() {
     this.localInstructionalNotes = undefined;
+    this.isEditingInstructionalNotes = false;
   }
 
   @action
@@ -328,6 +334,7 @@ export default class SessionOverview extends Component {
     this.args.session.description = this.description;
     await this.args.session.save();
     this.localDescription = undefined;
+    this.isEditingDescription = false;
   });
 
   @action
@@ -347,6 +354,7 @@ export default class SessionOverview extends Component {
   @action
   revertDescriptionChanges() {
     this.localDescription = undefined;
+    this.isEditingDescription = false;
   }
 
   @action
@@ -373,6 +381,7 @@ export default class SessionOverview extends Component {
 
     await this.args.session.save();
     this.localInstructionalNotes = undefined;
+    this.isEditingInstructionalNotes = false;
   });
   <template>
     <div data-test-session-overview>
@@ -601,73 +610,85 @@ export default class SessionOverview extends Component {
               <hr />
               <div class="sessiondescription" data-test-description>
                 <label>{{t "general.description"}}:</label>
-                <FadeText @text={{this.description}} as |ft|>
-                  {{#if @editable}}
-                    <EditableField
-                      @value={{this.description}}
-                      @isSaveDisabled={{this.validations.errors.description}}
-                      @save={{perform this.saveDescription}}
-                      @close={{this.revertDescriptionChanges}}
-                      @clickPrompt={{t "general.clickToEdit"}}
-                    >
-                      <:default>
-                        <HtmlEditor
-                          @content={{this.description}}
-                          @update={{this.changeDescription}}
-                          @autofocus={{true}}
-                        />
-                        <YupValidationMessage
-                          @description={{t "general.description"}}
-                          @validationErrors={{this.validations.errors.description}}
-                        />
-                      </:default>
-                      <:value>
-                        {{ft.text}}
-                      </:value>
-                      <:postValue>
-                        {{ft.controls}}
-                      </:postValue>
-                    </EditableField>
-                  {{else}}
-                    {{ft.text preserveLinks=true}}
-                    {{ft.controls}}
-                  {{/if}}
-                </FadeText>
+                {{#if @editable}}
+                  <EditableText
+                    @value={{this.description}}
+                    @save={{perform this.saveDescription}}
+                    @close={{this.revertDescriptionChanges}}
+                    @isEditing={{this.isEditingDescription}}
+                    @isSaveDisabled={{this.validations.errors.description}}
+                    @edit={{set this "isEditingDescription" true}}
+                  >
+                    <:default>
+                      <HtmlEditor
+                        @content={{this.description}}
+                        @update={{this.changeDescription}}
+                        @autofocus={{true}}
+                      />
+                      <YupValidationMessage
+                        @description={{t "general.description"}}
+                        @validationErrors={{this.validations.errors.description}}
+                      />
+                    </:default>
+                    <:value>
+                      <FadeText @text={{this.description}}>
+                        <:additionalControls>
+                          <button
+                            class="edit"
+                            data-test-edit
+                            type="button"
+                            {{on "click" (set this "isEditingDescription")}}
+                          >
+                            {{t "general.edit"}}
+                          </button>
+                        </:additionalControls>
+                      </FadeText>
+                    </:value>
+                  </EditableText>
+                {{else}}
+                  <FadeText @text={{this.description}} />
+                {{/if}}
               </div>
               <div class="instructional-notes" data-test-instructional-notes>
                 <label>{{t "general.instructionalNotes"}}:</label>
-                <FadeText @text={{this.instructionalNotes}} as |ft|>
-                  {{#if @editable}}
-                    <EditableField
-                      @value={{this.instructionalNotes}}
-                      @isSaveDisabled={{this.validations.errors.instructionalNotes}}
-                      @save={{perform this.saveInstructionalNotes}}
-                      @close={{this.revertInstructionalNotesChanges}}
-                      @clickPrompt={{t "general.clickToEdit"}}
-                    >
-                      <:default>
-                        <HtmlEditor
-                          @content={{this.instructionalNotes}}
-                          @update={{this.changeInstructionalNotes}}
-                          @autofocus={{true}}
-                        />
-                        <YupValidationMessage
-                          @description={{t "general.instructionalNotes"}}
-                          @validationErrors={{this.validations.errors.instructionalNotes}}
-                        />
-                      </:default>
-                      <:value>
-                        {{ft.text}}
-                      </:value>
-                      <:postValue>
-                        {{ft.controls}}
-                      </:postValue>
-                    </EditableField>
-                  {{else}}
-                    {{ft.text preserveLinks=true}}
-                    {{ft.controls}}
-                  {{/if}}
-                </FadeText>
+                {{#if @editable}}
+                  <EditableText
+                    @value={{this.instructionalNotes}}
+                    @save={{perform this.saveInstructionalNotes}}
+                    @close={{this.revertInstructionalNotesChanges}}
+                    @isEditing={{this.isEditingInstructionalNotes}}
+                    @isSaveDisabled={{this.validations.errors.instructionalNotes}}
+                    @edit={{set this "isEditingInstructionalNotes" true}}
+                  >
+                    <:default>
+                      <HtmlEditor
+                        @content={{this.instructionalNotes}}
+                        @update={{this.changeInstructionalNotes}}
+                        @autofocus={{true}}
+                      />
+                      <YupValidationMessage
+                        @description={{t "general.instructionalNotes"}}
+                        @validationErrors={{this.validations.errors.instructionalNotes}}
+                      />
+                    </:default>
+                    <:value>
+                      <FadeText @text={{this.instructionalNotes}}>
+                        <:additionalControls>
+                          <button
+                            class="edit"
+                            data-test-edit
+                            type="button"
+                            {{on "click" (set this "isEditingInstructionalNotes")}}
+                          >
+                            {{t "general.edit"}}
+                          </button>
+                        </:additionalControls>
+                      </FadeText>
+                    </:value>
+                  </EditableText>
+                {{else}}
+                  <FadeText @text={{this.instructionalNotes}} />
+                {{/if}}
               </div>
               {{#unless this.isIndependentLearning}}
                 <br />

--- a/packages/ilios-common/addon/components/session/overview.gjs
+++ b/packages/ilios-common/addon/components/session/overview.gjs
@@ -28,6 +28,7 @@ import HtmlEditor from 'ilios-common/components/html-editor';
 import YupValidationMessage from 'ilios-common/components/yup-validation-message';
 import join from 'ilios-common/helpers/join';
 import mapBy from 'ilios-common/helpers/map-by';
+import FadeText from 'ilios-common/components/fade-text';
 
 export default class SessionOverview extends Component {
   @service currentUser;
@@ -599,22 +600,28 @@ export default class SessionOverview extends Component {
                   {{#if @editable}}
                     <EditableField
                       @value={{this.description}}
-                      @renderHtml={{true}}
                       @isSaveDisabled={{this.validations.errors.description}}
                       @save={{perform this.saveDescription}}
                       @close={{this.revertDescriptionChanges}}
-                      @fadeTextExpanded={{this.descriptionFadeTextExpanded}}
-                      @onExpandAllFadeText={{this.expandAllDescriptionFadeText}}
                       @clickPrompt={{t "general.clickToEdit"}}
                     >
-                      <HtmlEditor
-                        @content={{this.description}}
-                        @update={{this.changeDescription}}
-                      />
-                      <YupValidationMessage
-                        @description={{t "general.description"}}
-                        @validationErrors={{this.validations.errors.description}}
-                      />
+                      <:default>
+                        <HtmlEditor
+                          @content={{this.description}}
+                          @update={{this.changeDescription}}
+                        />
+                        <YupValidationMessage
+                          @description={{t "general.description"}}
+                          @validationErrors={{this.validations.errors.description}}
+                        />
+                      </:default>
+                      <:value>
+                        <FadeText
+                          @expanded={{this.descriptionFadeTextExpanded}}
+                          @onExpandAll={{this.expandAllDescriptionFadeText}}
+                          @text={{this.description}}
+                        />
+                      </:value>
                     </EditableField>
                   {{else}}
                     {{! template-lint-disable no-triple-curlies}}
@@ -632,18 +639,25 @@ export default class SessionOverview extends Component {
                       @isSaveDisabled={{this.validations.errors.instructionalNotes}}
                       @save={{perform this.saveInstructionalNotes}}
                       @close={{this.revertInstructionalNotesChanges}}
-                      @fadeTextExpanded={{this.notesFadeTextExpanded}}
-                      @onExpandAllFadeText={{this.expandAllNotesFadeText}}
                       @clickPrompt={{t "general.clickToEdit"}}
                     >
-                      <HtmlEditor
-                        @content={{this.instructionalNotes}}
-                        @update={{this.changeInstructionalNotes}}
-                      />
-                      <YupValidationMessage
-                        @description={{t "general.instructionalNotes"}}
-                        @validationErrors={{this.validations.errors.instructionalNotes}}
-                      />
+                      <:default>
+                        <HtmlEditor
+                          @content={{this.instructionalNotes}}
+                          @update={{this.changeInstructionalNotes}}
+                        />
+                        <YupValidationMessage
+                          @description={{t "general.instructionalNotes"}}
+                          @validationErrors={{this.validations.errors.instructionalNotes}}
+                        />
+                      </:default>
+                      <:value>
+                        <FadeText
+                          @expanded={{this.notesFadeTextExpanded}}
+                          @onExpandAll={{this.expandAllNotesFadeText}}
+                          @text={{this.instructionalNotes}}
+                        />
+                      </:value>
                     </EditableField>
                   {{else}}
                     {{! template-lint-disable no-triple-curlies}}

--- a/packages/ilios-common/addon/components/session/overview.gjs
+++ b/packages/ilios-common/addon/components/session/overview.gjs
@@ -29,6 +29,7 @@ import YupValidationMessage from 'ilios-common/components/yup-validation-message
 import join from 'ilios-common/helpers/join';
 import mapBy from 'ilios-common/helpers/map-by';
 import FadeText from 'ilios-common/components/fade-text';
+import focus from 'ilios-common/modifiers/focus';
 
 export default class SessionOverview extends Component {
   @service currentUser;
@@ -423,7 +424,11 @@ export default class SessionOverview extends Component {
                       @save={{this.changeSessionType}}
                       @close={{this.revertSessionTypeChanges}}
                     >
-                      <select id="session-type-{{templateId}}" {{on "change" this.setSessionType}}>
+                      <select
+                        id="session-type-{{templateId}}"
+                        {{on "change" this.setSessionType}}
+                        {{focus}}
+                      >
                         {{#each this.sortedSessionTypes as |sessionType|}}
                           <option
                             value={{sessionType.id}}

--- a/packages/ilios-common/addon/components/session/overview.gjs
+++ b/packages/ilios-common/addon/components/session/overview.gjs
@@ -629,7 +629,7 @@ export default class SessionOverview extends Component {
                       </:postValue>
                     </EditableField>
                   {{else}}
-                    {{ft.text}}
+                    {{ft.text preserveLinks=true}}
                     {{ft.controls}}
                   {{/if}}
                 </FadeText>
@@ -664,7 +664,7 @@ export default class SessionOverview extends Component {
                       </:postValue>
                     </EditableField>
                   {{else}}
-                    {{ft.text}}
+                    {{ft.text preserveLinks=true}}
                     {{ft.controls}}
                   {{/if}}
                 </FadeText>

--- a/packages/ilios-common/addon/components/session/overview.gjs
+++ b/packages/ilios-common/addon/components/session/overview.gjs
@@ -596,7 +596,7 @@ export default class SessionOverview extends Component {
               <hr />
               <div class="sessiondescription" data-test-description>
                 <label>{{t "general.description"}}:</label>
-                <span>
+                <FadeText @text={{this.description}} as |ft|>
                   {{#if @editable}}
                     <EditableField
                       @value={{this.description}}
@@ -609,6 +609,7 @@ export default class SessionOverview extends Component {
                         <HtmlEditor
                           @content={{this.description}}
                           @update={{this.changeDescription}}
+                          @autofocus={{true}}
                         />
                         <YupValidationMessage
                           @description={{t "general.description"}}
@@ -616,26 +617,24 @@ export default class SessionOverview extends Component {
                         />
                       </:default>
                       <:value>
-                        <FadeText
-                          @expanded={{this.descriptionFadeTextExpanded}}
-                          @onExpandAll={{this.expandAllDescriptionFadeText}}
-                          @text={{this.description}}
-                        />
+                        {{ft.text}}
                       </:value>
+                      <:postValue>
+                        {{ft.controls}}
+                      </:postValue>
                     </EditableField>
                   {{else}}
-                    {{! template-lint-disable no-triple-curlies}}
-                    {{{this.description}}}
+                    {{ft.text}}
+                    {{ft.controls}}
                   {{/if}}
-                </span>
+                </FadeText>
               </div>
               <div class="instructional-notes" data-test-instructional-notes>
                 <label>{{t "general.instructionalNotes"}}:</label>
-                <span>
+                <FadeText @text={{this.instructionalNotes}} as |ft|>
                   {{#if @editable}}
                     <EditableField
-                      @value={{@session.instructionalNotes}}
-                      @renderHtml={{true}}
+                      @value={{this.instructionalNotes}}
                       @isSaveDisabled={{this.validations.errors.instructionalNotes}}
                       @save={{perform this.saveInstructionalNotes}}
                       @close={{this.revertInstructionalNotesChanges}}
@@ -645,6 +644,7 @@ export default class SessionOverview extends Component {
                         <HtmlEditor
                           @content={{this.instructionalNotes}}
                           @update={{this.changeInstructionalNotes}}
+                          @autofocus={{true}}
                         />
                         <YupValidationMessage
                           @description={{t "general.instructionalNotes"}}
@@ -652,18 +652,17 @@ export default class SessionOverview extends Component {
                         />
                       </:default>
                       <:value>
-                        <FadeText
-                          @expanded={{this.notesFadeTextExpanded}}
-                          @onExpandAll={{this.expandAllNotesFadeText}}
-                          @text={{this.instructionalNotes}}
-                        />
+                        {{ft.text}}
                       </:value>
+                      <:postValue>
+                        {{ft.controls}}
+                      </:postValue>
                     </EditableField>
                   {{else}}
-                    {{! template-lint-disable no-triple-curlies}}
-                    {{{this.instructionalNotes}}}
+                    {{ft.text}}
+                    {{ft.controls}}
                   {{/if}}
-                </span>
+                </FadeText>
               </div>
               {{#unless this.isIndependentLearning}}
                 <br />

--- a/packages/ilios-common/addon/components/sessions-grid-offering.gjs
+++ b/packages/ilios-common/addon/components/sessions-grid-offering.gjs
@@ -24,6 +24,7 @@ import FaIcon from 'ilios-common/components/fa-icon';
 import YupValidations from 'ilios-common/classes/yup-validations';
 import YupValidationMessage from 'ilios-common/components/yup-validation-message';
 import { string } from 'yup';
+import focus from 'ilios-common/modifiers/focus';
 
 export default class SessionsGridOffering extends Component {
   @tracked roomBuffer;
@@ -206,6 +207,7 @@ export default class SessionsGridOffering extends Component {
                   {{on "input" (pick "target.value" (set this "roomBuffer"))}}
                   {{this.validations.attach "room"}}
                   {{keyboard}}
+                  {{focus}}
                 />
                 <YupValidationMessage
                   @description={{t "general.location"}}

--- a/packages/ilios-common/addon/components/sessions-grid-offering.gjs
+++ b/packages/ilios-common/addon/components/sessions-grid-offering.gjs
@@ -195,9 +195,7 @@ export default class SessionsGridOffering extends Component {
                 @value={{this.room}}
                 @save={{perform this.changeRoom}}
                 @close={{this.revertRoomChanges}}
-                @saveOnEnter={{true}}
-                @closeOnEscape={{true}}
-                as |isSaving|
+                as |keyboard isSaving|
               >
                 <input
                   aria-label={{t "general.room"}}
@@ -207,6 +205,7 @@ export default class SessionsGridOffering extends Component {
                   disabled={{isSaving}}
                   {{on "input" (pick "target.value" (set this "roomBuffer"))}}
                   {{this.validations.attach "room"}}
+                  {{keyboard}}
                 />
                 <YupValidationMessage
                   @description={{t "general.location"}}

--- a/packages/ilios-common/app/components/editable-text.js
+++ b/packages/ilios-common/app/components/editable-text.js
@@ -1,0 +1,1 @@
+export { default } from 'ilios-common/components/editable-text';

--- a/packages/ilios-common/app/styles/ilios-common/components.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components.scss
@@ -28,6 +28,7 @@
 @forward "components/detail-mesh";
 @forward "components/detail-taxonomies";
 @forward "components/detail-terms-list";
+@forward "components/editable-text";
 @forward "components/editinplace";
 @forward "components/ellipsis-icon";
 @forward "components/event-not-found";

--- a/packages/ilios-common/app/styles/ilios-common/components/course/objective-list.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/course/objective-list.scss
@@ -3,20 +3,4 @@
 
 .course-objective-list {
   @include m.objective-list;
-
-  .fade-text-control {
-    background-image: linear-gradient(to bottom, transparent, var(--white));
-  }
-
-  .objective-row {
-    &.is-managing {
-      .fade-text-control {
-        background-image: linear-gradient(
-          to bottom,
-          transparent,
-          var(--lightest-grey)
-        );
-      }
-    }
-  }
 }

--- a/packages/ilios-common/app/styles/ilios-common/components/course/objective-list.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/course/objective-list.scss
@@ -3,4 +3,12 @@
 
 .course-objective-list {
   @include m.objective-list;
+
+  .objective-row {
+    button {
+      &.edit {
+        @include m.ilios-button;
+      }
+    }
+  }
 }

--- a/packages/ilios-common/app/styles/ilios-common/components/editable-text.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/editable-text.scss
@@ -1,0 +1,41 @@
+@use "../colors" as c;
+@use "../mixins" as m;
+
+.editable-text {
+  .editor {
+    @include m.ilios-form-error;
+    align-items: center;
+    display: flex;
+
+    .actions {
+      display: flex;
+      justify-content: flex-start;
+
+      button {
+        background: transparent;
+        margin: 0;
+        padding: 0 0.2rem;
+
+        &:enabled:hover {
+          color: var(--white);
+        }
+
+        &.done {
+          color: var(--green);
+
+          &:enabled:hover {
+            background-color: var(--green);
+          }
+        }
+
+        &.cancel {
+          color: var(--red);
+
+          &:enabled:hover {
+            background-color: var(--red);
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/ilios-common/app/styles/ilios-common/components/editinplace.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/editinplace.scss
@@ -60,10 +60,4 @@
   .fa-pen-to-square {
     @include m.icon;
   }
-
-  .expand-text-button,
-  .collapse-text-button {
-    @include m.ilios-link-button;
-    display: inline;
-  }
 }

--- a/packages/ilios-common/app/styles/ilios-common/components/fade-text.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/fade-text.scss
@@ -6,7 +6,7 @@
     display: inline-block;
 
     &.faded {
-      max-height: 200px;
+      max-height: 180px;
       overflow: hidden;
       position: relative;
 
@@ -17,15 +17,7 @@
   button {
     &.expand-text-button,
     &.collapse-text-button {
-      @include m.ilios-link-button;
-      display: block;
-    }
-  }
-
-  .fade-text-control {
-    padding: 0;
-    button {
-      @include m.ilios-link-button;
+      @include m.ilios-button;
     }
   }
 }

--- a/packages/ilios-common/app/styles/ilios-common/components/fade-text.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/fade-text.scss
@@ -9,6 +9,8 @@
       max-height: 200px;
       overflow: hidden;
       position: relative;
+
+      mask-image: linear-gradient(to bottom, black 70%, transparent 100%);
     }
   }
 
@@ -21,16 +23,9 @@
   }
 
   .fade-text-control {
-    bottom: 105px;
-    cursor: pointer;
-    height: 110px;
     padding: 0;
-    position: relative;
-
     button {
       @include m.ilios-link-button;
-      position: relative;
-      top: 110px;
     }
   }
 }

--- a/packages/ilios-common/app/styles/ilios-common/components/print-course.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/print-course.scss
@@ -60,14 +60,11 @@
   }
 
   .fade-text {
-    .fade-text-control {
-      height: auto;
-    }
-
     .display-text-wrapper {
       &.faded {
         max-height: none;
         overflow: visible;
+        mask-image: none;
       }
     }
 

--- a/packages/ilios-common/app/styles/ilios-common/components/session-overview.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/session-overview.scss
@@ -96,14 +96,6 @@
   .instructional-notes {
     @include m.ilios-browser-defaults;
     grid-column: 1 / -1;
-
-    .fade-text-control {
-      background-image: linear-gradient(
-        to bottom,
-        transparent,
-        var(--lightest-blue)
-      );
-    }
   }
 
   .sessionassociatedgroups {

--- a/packages/ilios-common/app/styles/ilios-common/components/session/objective-list.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/session/objective-list.scss
@@ -3,24 +3,4 @@
 
 .session-objective-list {
   @include m.objective-list;
-
-  .fade-text-control {
-    background-image: linear-gradient(
-      to bottom,
-      transparent,
-      var(--lightest-blue)
-    );
-  }
-
-  .objective-row {
-    &.is-managing {
-      .fade-text-control {
-        background-image: linear-gradient(
-          to bottom,
-          transparent,
-          var(--lightest-grey)
-        );
-      }
-    }
-  }
 }

--- a/packages/ilios-common/app/styles/ilios-common/components/session/objective-list.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/session/objective-list.scss
@@ -3,4 +3,12 @@
 
 .session-objective-list {
   @include m.objective-list;
+
+  .objective-row {
+    button {
+      &.edit {
+        @include m.ilios-button;
+      }
+    }
+  }
 }

--- a/packages/ilios-common/app/styles/ilios-common/mixins/objectives.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/objectives.scss
@@ -139,14 +139,6 @@
         @include font-size.font-size("base");
         margin: 0;
       }
-      button {
-        @include ilios-button.ilios-link-button;
-        @include font-size.font-size("base");
-
-        p {
-          @include font-size.font-size("base");
-        }
-      }
     }
 
     .course-objective-list-item-parents,

--- a/packages/ilios-common/app/styles/ilios-common/mixins/sort-manager.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/sort-manager.scss
@@ -21,18 +21,6 @@
 
   .content {
     padding-top: 0.5rem;
-
-    span {
-      &.draggable-object-content {
-        .fade-text-control {
-          background-image: linear-gradient(
-            to bottom,
-            transparent,
-            var(--lightest-grey)
-          );
-        }
-      }
-    }
   }
 
   .sortable-items {

--- a/packages/ilios-common/app/styles/ilios-common/mixins/sort-manager.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/sort-manager.scss
@@ -59,14 +59,6 @@
             margin: 0;
           }
         }
-        button {
-          &.expand-text-button {
-            background: var(--blue);
-            border-radius: 3px;
-            color: var(--white);
-            padding: 0.3em 1em;
-          }
-        }
       }
 
       &.dragging-item {

--- a/packages/ilios-common/package.json
+++ b/packages/ilios-common/package.json
@@ -65,6 +65,7 @@
     "normalize.css": "^8.0.1",
     "query-string": ">= 9.1.0",
     "quill": "^2.0.3",
+    "sanitize-html": "^2.17.0",
     "striptags": ">= 3.2.0",
     "typeface-nunito": ">= 1.1.13",
     "typeface-nunito-sans": ">= 1.1.13",

--- a/packages/test-app/tests/integration/components/course/objective-list-item-test.gjs
+++ b/packages/test-app/tests/integration/components/course/objective-list-item-test.gjs
@@ -31,7 +31,7 @@ module('Integration | Component | course/objective-list-item', function (hooks) 
       </template>,
     );
     assert.notOk(component.hasRemoveConfirmation);
-    assert.strictEqual(component.description.text, 'course objective 0');
+    assert.strictEqual(component.description.fadeText.displayText.text, 'course objective 0');
     assert.strictEqual(component.parents.text, 'Add New');
     assert.strictEqual(component.meshDescriptors.text, 'Add New');
     assert.ok(component.hasTrashCan);
@@ -59,11 +59,11 @@ module('Integration | Component | course/objective-list-item', function (hooks) 
       </template>,
     );
     const newDescription = 'Pluto Visits Earth';
-    assert.strictEqual(component.description.text, 'course objective 0');
+    assert.strictEqual(component.description.fadeText.displayText.text, 'course objective 0');
     await component.description.openEditor();
     await component.description.edit(newDescription);
     await component.description.save();
-    assert.strictEqual(component.description.text, newDescription);
+    assert.strictEqual(component.description.fadeText.displayText.text, newDescription);
   });
 
   test('can manage parents', async function (assert) {

--- a/packages/test-app/tests/integration/components/course/objective-list-test.gjs
+++ b/packages/test-app/tests/integration/components/course/objective-list-test.gjs
@@ -41,7 +41,10 @@ module('Integration | Component | course/objective-list', function (hooks) {
     assert.strictEqual(component.headers[4].text, 'Actions');
 
     assert.strictEqual(component.objectives.length, 2);
-    assert.strictEqual(component.objectives[0].description.text, 'Objective B');
+    assert.strictEqual(
+      component.objectives[0].description.fadeText.displayText.text,
+      'Objective B',
+    );
     assert.strictEqual(
       component.objectives[0].selectedTerms.list[0].title,
       'Vocabulary 1 (school 0)',
@@ -50,7 +53,10 @@ module('Integration | Component | course/objective-list', function (hooks) {
       component.objectives[0].selectedTerms.list[0].terms[0].name,
       'term 1 (inactive)',
     );
-    assert.strictEqual(component.objectives[1].description.text, 'Objective A');
+    assert.strictEqual(
+      component.objectives[1].description.fadeText.displayText.text,
+      'Objective A',
+    );
     assert.strictEqual(
       component.objectives[1].selectedTerms.list[0].title,
       'Vocabulary 1 (school 0)',

--- a/packages/test-app/tests/integration/components/course/objectives-test.gjs
+++ b/packages/test-app/tests/integration/components/course/objectives-test.gjs
@@ -47,7 +47,7 @@ module('Integration | Component | course/objectives', function (hooks) {
 
     assert.strictEqual(component.objectiveList.objectives.length, 2);
     assert.strictEqual(
-      component.objectiveList.objectives[0].description.text,
+      component.objectiveList.objectives[0].description.fadeText.displayText.text,
       'course objective 0',
     );
     assert.strictEqual(component.objectiveList.objectives[0].parents.list.length, 1);
@@ -58,7 +58,7 @@ module('Integration | Component | course/objectives', function (hooks) {
     assert.ok(component.objectiveList.objectives[0].meshDescriptors.empty);
 
     assert.strictEqual(
-      component.objectiveList.objectives[1].description.text,
+      component.objectiveList.objectives[1].description.fadeText.displayText.text,
       'course objective 1',
     );
     assert.ok(component.objectiveList.objectives[1].parents.empty);
@@ -103,7 +103,7 @@ module('Integration | Component | course/objectives', function (hooks) {
 
     assert.strictEqual(component.objectiveList.objectives.length, 1);
     assert.strictEqual(
-      component.objectiveList.objectives[0].description.text,
+      component.objectiveList.objectives[0].description.fadeText.displayText.text,
       'course objective 0',
     );
     assert.strictEqual(component.objectiveList.objectives[0].parents.list.length, 1);
@@ -182,7 +182,7 @@ module('Integration | Component | course/objectives', function (hooks) {
 
     assert.strictEqual(component.objectiveList.objectives.length, 1);
     assert.strictEqual(
-      component.objectiveList.objectives[0].description.text,
+      component.objectiveList.objectives[0].description.fadeText.displayText.text,
       'course objective 0',
     );
     assert.strictEqual(component.objectiveList.objectives[0].parents.list.length, 1);

--- a/packages/test-app/tests/integration/components/editable-field-test.gjs
+++ b/packages/test-app/tests/integration/components/editable-field-test.gjs
@@ -38,6 +38,20 @@ module('Integration | Component | editable field', function (hooks) {
     assert.strictEqual(component.value, 'template block text');
   });
 
+  test('it renders an edit icon when it looks empty', async function (assert) {
+    this.set(
+      'value',
+      `
+      <p>
+        &nbsp;
+      </p>
+    `,
+    );
+    await render(<template><EditableField @value={{this.value}} /></template>);
+    assert.strictEqual(component.value, '');
+    assert.strictEqual(component.editable.iconCount, 1);
+  });
+
   test('save on enter', async function (assert) {
     assert.expect(1);
     this.set('label', 'Foo');

--- a/packages/test-app/tests/integration/components/editable-field-test.gjs
+++ b/packages/test-app/tests/integration/components/editable-field-test.gjs
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { render, waitFor } from '@ember/test-helpers';
+import { render } from '@ember/test-helpers';
 import { setupIntl } from 'ember-intl/test-support';
 import { component } from 'ilios-common/page-objects/components/editable-field';
 import EditableField from 'ilios-common/components/editable-field';
@@ -17,12 +17,6 @@ module('Integration | Component | editable field', function (hooks) {
     await render(<template><EditableField @value="woot!" /></template>);
     assert.strictEqual(component.value, 'woot!');
     assert.notOk(component.hasEditIcon);
-  });
-
-  test('edit icon is present', async function (assert) {
-    await render(<template><EditableField @value="woot!" @showIcon={{true}} /></template>);
-    assert.strictEqual(component.value, 'woot!');
-    assert.ok(component.hasEditIcon);
   });
 
   test('it renders clickPrompt', async function (assert) {
@@ -42,20 +36,6 @@ module('Integration | Component | editable field', function (hooks) {
     assert.strictEqual(component.value, 'text');
     await component.editable.edit();
     assert.strictEqual(component.value, 'template block text');
-  });
-
-  test('it renders an edit icon when it looks empty', async function (assert) {
-    this.set(
-      'value',
-      `
-      <p>
-        &nbsp;
-      </p>
-    `,
-    );
-    await render(<template><EditableField @value={{this.value}} /></template>);
-    assert.strictEqual(component.value, '');
-    assert.strictEqual(component.editable.iconCount, 1);
   });
 
   test('save on enter', async function (assert) {
@@ -135,41 +115,6 @@ module('Integration | Component | editable field', function (hooks) {
     );
     await component.editable.edit();
     assert.ok(component.textareaHasFocus);
-  });
-
-  test('expand/collapse overlong html', async function (assert) {
-    const text = `
-      <p>A long list:</p><ol><li>One</li><li>two</li><li>Five!</li><li>Six</li><li>Seven but with extra text to make long</li><li>a</li><li>b</li><li>c</li><li>d</li><li>e</li><li>f</li><li>g</li><li>h</li><li>iii</li><li>Jjjjjj</li><li>k</li><li>lLLLLLLlll</li><li>mmmmmMMMMMmm</li><li>nnnnnOPE</li><li>ohno</li><li>pppppPowerbook</li></ol>
-    `;
-    const fadedSelector = '.faded';
-    this.set('value', text);
-    this.set('fadeTextIsExpanded', false);
-    this.set('expandAllFadeText', (isExpanded) => {
-      this.set('fadeTextIsExpanded', isExpanded);
-    });
-    await render(
-      <template>
-        <EditableField
-          @value={{this.value}}
-          @fadeTextExpanded={{this.fadeTextIsExpanded}}
-          @onExpandAllFadeText={{this.expandAllFadeText}}
-        />
-      </template>,
-    );
-
-    await waitFor(fadedSelector);
-
-    assert.ok(component.fadeText.enabled);
-    assert.ok(component.fadeText.displayText.isFaded);
-
-    await component.fadeText.control.expand.click();
-
-    assert.notOk(component.fadeText.displayText.isFaded);
-
-    await component.fadeText.control.collapse.click();
-    await waitFor(fadedSelector);
-
-    assert.ok(component.fadeText.displayText.isFaded);
   });
 
   test('sends status info', async function (assert) {

--- a/packages/test-app/tests/integration/components/editable-field-test.gjs
+++ b/packages/test-app/tests/integration/components/editable-field-test.gjs
@@ -88,35 +88,6 @@ module('Integration | Component | editable field', function (hooks) {
     await component.escape();
   });
 
-  test('focus when editor opens on input', async function (assert) {
-    this.set('value', 'lorem');
-    this.set('label', 'Foo');
-    await render(
-      <template>
-        <EditableField @value={{this.value}}>
-          <label><input />{{this.label}}</label>
-        </EditableField>
-      </template>,
-    );
-    await component.editable.edit();
-    assert.ok(component.inputHasFocus);
-  });
-
-  test('focus when editor opens on textarea', async function (assert) {
-    this.set('value', 'lorem');
-    this.set('label', 'Foo Bar');
-    await render(
-      <template>
-        <EditableField @value={{this.value}}>
-          <label for="textarea">{{this.label}}</label>
-          <textarea id="textarea"></textarea>
-        </EditableField>
-      </template>,
-    );
-    await component.editable.edit();
-    assert.ok(component.textareaHasFocus);
-  });
-
   test('sends status info', async function (assert) {
     this.set('status', false);
     await render(

--- a/packages/test-app/tests/integration/components/editable-field-test.gjs
+++ b/packages/test-app/tests/integration/components/editable-field-test.gjs
@@ -67,9 +67,13 @@ module('Integration | Component | editable field', function (hooks) {
     });
     await render(
       <template>
-        <EditableField @save={{this.save}} @saveOnEnter={{true}} @value={{this.value}}>
+        <EditableField @save={{this.save}} @value={{this.value}} as |keyboard|>
           <label>
-            <input value={{this.value}} {{on "input" (pick "target.value" (set this "value"))}} />
+            <input
+              value={{this.value}}
+              {{on "input" (pick "target.value" (set this "value"))}}
+              {{keyboard}}
+            />
             {{this.label}}
           </label>
         </EditableField>
@@ -88,9 +92,13 @@ module('Integration | Component | editable field', function (hooks) {
     });
     await render(
       <template>
-        <EditableField @close={{this.revert}} @closeOnEscape={{true}} @value={{this.value}}>
+        <EditableField @close={{this.revert}} @value={{this.value}} as |keyboard|>
           <label>
-            <input value={{this.value}} {{on "input" (pick "target.value" (set this "value"))}} />
+            <input
+              value={{this.value}}
+              {{on "input" (pick "target.value" (set this "value"))}}
+              {{keyboard}}
+            />
             {{this.label}}
           </label>
         </EditableField>
@@ -193,5 +201,55 @@ module('Integration | Component | editable field', function (hooks) {
     );
 
     assert.strictEqual(component.editable.title, 'Edit');
+  });
+
+  test('ignores save on enter', async function (assert) {
+    assert.expect(0);
+    this.set('label', 'Foo');
+    this.set('value', 'lorem');
+    this.set('save', () => {
+      assert.ok(false, 'should never be called');
+    });
+    await render(
+      <template>
+        <EditableField @save={{this.save}} @value={{this.value}} as |keyboard|>
+          <label>
+            <input
+              value={{this.value}}
+              {{on "input" (pick "target.value" (set this "value"))}}
+              {{keyboard saveOnEnter=false}}
+            />
+            {{this.label}}
+          </label>
+        </EditableField>
+      </template>,
+    );
+    await component.editable.edit();
+    await component.enter();
+  });
+
+  test('ignored close on escape', async function (assert) {
+    assert.expect(0);
+    this.set('label', 'Foo');
+    this.set('value', 'lorem');
+    this.set('revert', () => {
+      assert.ok(false, 'should never be called');
+    });
+    await render(
+      <template>
+        <EditableField @close={{this.revert}} @value={{this.value}} as |keyboard|>
+          <label>
+            <input
+              value={{this.value}}
+              {{on "input" (pick "target.value" (set this "value"))}}
+              {{keyboard closeOnEscape=false}}
+            />
+            {{this.label}}
+          </label>
+        </EditableField>
+      </template>,
+    );
+    await component.editable.edit();
+    await component.escape();
   });
 });

--- a/packages/test-app/tests/integration/components/editable-text-test.gjs
+++ b/packages/test-app/tests/integration/components/editable-text-test.gjs
@@ -39,25 +39,16 @@ module('Integration | Component | editable-text', function (hooks) {
     assert.strictEqual(component.editable.text, 'Click to edit');
   });
 
-  test('it renders a "click to edit" button when it looks empty', async function (assert) {
-    assert.expect(2);
-    this.set('edit', () => {
-      assert.ok(true, 'edit action fired.');
-    });
-    this.set(
-      'value',
-      `
-      <p>
-        &nbsp;
-      </p>
-    `,
+  test('is save disabled', async function (assert) {
+    await render(
+      <template>
+        <EditableText @value={{this.value}} @isEditing={{true}} @isSaveDisabled={{true}} />
+      </template>,
     );
-    await render(<template><EditableText @value={{this.value}} @edit={{this.edit}} /></template>);
-    assert.strictEqual(component.editable.text, 'Click to edit');
-    await component.editable.edit();
+    assert.ok(component.isSaveDisabled);
   });
 
-  test('edit, save, and close', async function (assert) {
+  test('edit', async function (assert) {
     assert.expect(2);
     this.set('edit', () => {
       assert.ok(true, 'edit action fired.');
@@ -76,7 +67,7 @@ module('Integration | Component | editable-text', function (hooks) {
   });
 
   test('save and close', async function (assert) {
-    assert.expect(2);
+    assert.expect(3);
     this.set('save', () => {
       assert.ok(true, 'save action fired.');
     });
@@ -89,6 +80,7 @@ module('Integration | Component | editable-text', function (hooks) {
         <EditableText @isEditing={{true}} @save={{this.save}} @close={{this.close}} />
       </template>,
     );
+    assert.notOk(component.isSaveDisabled);
     await component.save();
   });
 

--- a/packages/test-app/tests/integration/components/editable-text-test.gjs
+++ b/packages/test-app/tests/integration/components/editable-text-test.gjs
@@ -1,0 +1,104 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'test-app/tests/helpers';
+import { render } from '@ember/test-helpers';
+import { setupIntl } from 'ember-intl/test-support';
+import { component } from 'ilios-common/page-objects/components/editable-text';
+import EditableText from 'ilios-common/components/editable-text';
+
+module('Integration | Component | editable-text', function (hooks) {
+  setupRenderingTest(hooks);
+  setupIntl(hooks, 'en-us');
+
+  test('it renders value in read-mode', async function (assert) {
+    await render(<template><EditableText @value="woot!" /></template>);
+    assert.strictEqual(component.value, 'woot!');
+  });
+
+  test('it renders content in edit-mode', async function (assert) {
+    this.set('content', 'template block text');
+    await render(
+      <template>
+        <EditableText @value="text" @isEditing={{true}}>
+          {{this.content}}
+        </EditableText>
+      </template>,
+    );
+    assert.strictEqual(component.value, 'template block text');
+  });
+
+  test('it renders a "click to edit" button when it looks empty', async function (assert) {
+    this.set(
+      'value',
+      `
+      <p>
+        &nbsp;
+      </p>
+    `,
+    );
+    await render(<template><EditableText @value={{this.value}} /></template>);
+    assert.strictEqual(component.editable.text, 'Click to edit');
+  });
+
+  test('it renders a "click to edit" button when it looks empty', async function (assert) {
+    assert.expect(2);
+    this.set('edit', () => {
+      assert.ok(true, 'edit action fired.');
+    });
+    this.set(
+      'value',
+      `
+      <p>
+        &nbsp;
+      </p>
+    `,
+    );
+    await render(<template><EditableText @value={{this.value}} @edit={{this.edit}} /></template>);
+    assert.strictEqual(component.editable.text, 'Click to edit');
+    await component.editable.edit();
+  });
+
+  test('edit, save, and close', async function (assert) {
+    assert.expect(2);
+    this.set('edit', () => {
+      assert.ok(true, 'edit action fired.');
+    });
+    this.set(
+      'value',
+      `
+      <p>
+        &nbsp;
+      </p>
+    `,
+    );
+    await render(<template><EditableText @value={{this.value}} @edit={{this.edit}} /></template>);
+    assert.strictEqual(component.editable.text, 'Click to edit');
+    await component.editable.edit();
+  });
+
+  test('save and close', async function (assert) {
+    assert.expect(2);
+    this.set('save', () => {
+      assert.ok(true, 'save action fired.');
+    });
+    this.set('close', () => {
+      assert.ok(true, 'close action fired.');
+    });
+    this.set('value', 'lorem ipsum');
+    await render(
+      <template>
+        <EditableText @isEditing={{true}} @save={{this.save}} @close={{this.close}} />
+      </template>,
+    );
+    await component.save();
+  });
+
+  test('close', async function (assert) {
+    assert.expect(1);
+    this.set('close', () => {
+      assert.ok(true, 'close action fired.');
+    });
+    this.set('value', 'lorem ipsum');
+    await render(<template><EditableText @isEditing={{true}} @close={{this.close}} /></template>);
+    await component.cancel();
+  });
+});

--- a/packages/test-app/tests/integration/components/fade-text-test.gjs
+++ b/packages/test-app/tests/integration/components/fade-text-test.gjs
@@ -39,6 +39,42 @@ module('Integration | Component | fade-text', function (hooks) {
   test('it renders short text in full', async function (assert) {
     const shortText = 'template block text';
     this.set('shortText', shortText);
+    await render(<template><FadeText @text={{this.shortText}} /></template>);
+    assert.notOk(component.enabled);
+    assert.false(component.displayText.isFaded);
+    assert.dom(this.element).hasText(shortText);
+  });
+
+  test('it fades tall text given as component argument', async function (assert) {
+    this.set('longHtml', this.longHtml);
+
+    this.set('expanded', false);
+    this.set('setExpanded', (isExpanded) => {
+      this.set('expanded', isExpanded);
+    });
+    await render(
+      <template><FadeText @text={{this.longHtml}} @setExpanded={{this.setExpanded}} /></template>,
+    );
+    assert.ok(component.enabled);
+    assert.notOk(this.expanded, 'text is not expanded');
+    assert.ok(component.displayText.isFaded);
+
+    await component.control.expand.click();
+
+    assert.ok(component.enabled);
+    assert.ok(this.expanded);
+    assert.notOk(component.displayText.isFaded);
+
+    await component.control.collapse.click();
+
+    assert.ok(component.enabled);
+    assert.notOk(this.expanded);
+    assert.ok(component.displayText.isFaded);
+  });
+
+  test('it renders short text in full in block form', async function (assert) {
+    const shortText = 'template block text';
+    this.set('shortText', shortText);
     await render(
       <template>
         <FadeText @text={{this.shortText}} as |ft|>
@@ -52,7 +88,7 @@ module('Integration | Component | fade-text', function (hooks) {
     assert.dom(this.element).hasText(shortText);
   });
 
-  test('it fades tall text given as component argument', async function (assert) {
+  test('it fades tall text given as component argument in block form', async function (assert) {
     this.set('longHtml', this.longHtml);
 
     this.set('expanded', false);

--- a/packages/test-app/tests/integration/components/fade-text-test.gjs
+++ b/packages/test-app/tests/integration/components/fade-text-test.gjs
@@ -26,6 +26,8 @@ module('Integration | Component | fade-text', function (hooks) {
     `;
     this.fadedClass = 'faded';
     this.fadedSelector = '.faded';
+    this.linkText = '<p class="text"><a href="iliosproject.org">Ilios Project</a></p>';
+    this.cleanText = '<p class="text"><span class="link">Ilios Project</span></p>';
   });
 
   test('it renders empty', async function (assert) {
@@ -118,5 +120,44 @@ module('Integration | Component | fade-text', function (hooks) {
     assert.ok(component.enabled);
     assert.notOk(this.expanded);
     assert.ok(component.displayText.isFaded);
+  });
+
+  test('it replaces links by default', async function (assert) {
+    this.set('text', this.linkText);
+    await render(<template><FadeText @text={{this.text}} /></template>);
+    assert.dom('[data-test-text]', this.element).hasHtml(this.cleanText);
+
+    await render(
+      <template>
+        <FadeText @text={{this.text}} as |ft|>
+          {{ft.text}}
+        </FadeText>
+      </template>,
+    );
+    assert.dom('[data-test-text]', this.element).hasHtml(this.cleanText);
+  });
+
+  test('it preserves links when asked', async function (assert) {
+    this.set('text', this.linkText);
+    await render(<template><FadeText @text={{this.text}} @preserveLinks={{true}} /></template>);
+    assert.dom('[data-test-text]', this.element).hasHtml(this.linkText);
+
+    await render(
+      <template>
+        <FadeText @text={{this.text}} @preserveLinks={{true}} as |ft|>
+          {{ft.text}}
+        </FadeText>
+      </template>,
+    );
+    assert.dom('[data-test-text]', this.element).hasHtml(this.linkText);
+
+    await render(
+      <template>
+        <FadeText @text={{this.text}} as |ft|>
+          {{ft.text preserveLinks=true}}
+        </FadeText>
+      </template>,
+    );
+    assert.dom('[data-test-text]', this.element).hasHtml(this.linkText);
   });
 });

--- a/packages/test-app/tests/integration/components/fade-text-test.gjs
+++ b/packages/test-app/tests/integration/components/fade-text-test.gjs
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { render } from '@ember/test-helpers';
+import { render, waitFor } from '@ember/test-helpers';
 import { on } from '@ember/modifier';
 import t from 'ember-intl/helpers/t';
 import { component } from 'ilios-common/page-objects/components/fade-text';
@@ -59,6 +59,7 @@ module('Integration | Component | fade-text', function (hooks) {
     await render(
       <template><FadeText @text={{this.longHtml}} @setExpanded={{this.setExpanded}} /></template>,
     );
+    await waitFor('.faded');
     assert.ok(component.enabled);
     assert.notOk(this.expanded, 'text is not expanded');
     assert.ok(component.displayText.isFaded);
@@ -107,6 +108,7 @@ module('Integration | Component | fade-text', function (hooks) {
         </FadeText>
       </template>,
     );
+    await waitFor('.faded');
     assert.strictEqual(component.control.buttons.length, 2);
     assert.strictEqual(component.control.buttons[0].text, 'Edit');
     assert.strictEqual(component.control.buttons[1].title, 'Expand');

--- a/packages/test-app/tests/integration/components/fade-text-test.gjs
+++ b/packages/test-app/tests/integration/components/fade-text-test.gjs
@@ -1,6 +1,8 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
 import { render } from '@ember/test-helpers';
+import { on } from '@ember/modifier';
+import t from 'ember-intl/helpers/t';
 import { component } from 'ilios-common/page-objects/components/fade-text';
 import FadeText from 'ilios-common/components/fade-text';
 
@@ -90,74 +92,44 @@ module('Integration | Component | fade-text', function (hooks) {
     assert.dom(this.element).hasText(shortText);
   });
 
-  test('it fades tall text given as component argument in block form', async function (assert) {
-    this.set('longHtml', this.longHtml);
-
-    this.set('expanded', false);
-    this.set('setExpanded', (isExpanded) => {
-      this.set('expanded', isExpanded);
+  test('additional controls with faded text', async function (assert) {
+    assert.expect(4);
+    this.set('text', this.longHtml);
+    this.set('edit', () => {
+      assert.ok(true, 'edit button was clicked');
     });
     await render(
       <template>
-        <FadeText @text={{this.longHtml}} @setExpanded={{this.setExpanded}} as |ft|>
-          {{ft.text}}
-          {{ft.controls}}
+        <FadeText @text={{this.text}}>
+          <:additionalControls>
+            <button type="button" {{on "click" this.edit}}>{{t "general.edit"}}</button>
+          </:additionalControls>
         </FadeText>
       </template>,
     );
-    assert.ok(component.enabled);
-    assert.notOk(this.expanded, 'text is not expanded');
-    assert.ok(component.displayText.isFaded);
-
-    await component.control.expand.click();
-
-    assert.ok(component.enabled);
-    assert.ok(this.expanded);
-    assert.notOk(component.displayText.isFaded);
-
-    await component.control.collapse.click();
-
-    assert.ok(component.enabled);
-    assert.notOk(this.expanded);
-    assert.ok(component.displayText.isFaded);
+    assert.strictEqual(component.control.buttons.length, 2);
+    assert.strictEqual(component.control.buttons[0].text, 'Edit');
+    assert.strictEqual(component.control.buttons[1].title, 'Expand');
+    await component.control.buttons[0].click();
   });
 
-  test('it replaces links by default', async function (assert) {
-    this.set('text', this.linkText);
-    await render(<template><FadeText @text={{this.text}} /></template>);
-    assert.dom('[data-test-text]', this.element).hasHtml(this.cleanText);
-
+  test('additional controls with un-faded text', async function (assert) {
+    assert.expect(3);
+    this.set('text', 'foo bar');
+    this.set('edit', () => {
+      assert.ok(true, 'edit button was clicked');
+    });
     await render(
       <template>
-        <FadeText @text={{this.text}} as |ft|>
-          {{ft.text}}
+        <FadeText @text={{this.text}}>
+          <:additionalControls>
+            <button type="button" {{on "click" this.edit}}>{{t "general.edit"}}</button>
+          </:additionalControls>
         </FadeText>
       </template>,
     );
-    assert.dom('[data-test-text]', this.element).hasHtml(this.cleanText);
-  });
-
-  test('it preserves links when asked', async function (assert) {
-    this.set('text', this.linkText);
-    await render(<template><FadeText @text={{this.text}} @preserveLinks={{true}} /></template>);
-    assert.dom('[data-test-text]', this.element).hasHtml(this.linkText);
-
-    await render(
-      <template>
-        <FadeText @text={{this.text}} @preserveLinks={{true}} as |ft|>
-          {{ft.text}}
-        </FadeText>
-      </template>,
-    );
-    assert.dom('[data-test-text]', this.element).hasHtml(this.linkText);
-
-    await render(
-      <template>
-        <FadeText @text={{this.text}} as |ft|>
-          {{ft.text preserveLinks=true}}
-        </FadeText>
-      </template>,
-    );
-    assert.dom('[data-test-text]', this.element).hasHtml(this.linkText);
+    assert.strictEqual(component.control.buttons.length, 1);
+    assert.strictEqual(component.control.buttons[0].text, 'Edit');
+    await component.control.buttons[0].click();
   });
 });

--- a/packages/test-app/tests/integration/components/session/objective-list-item-test.gjs
+++ b/packages/test-app/tests/integration/components/session/objective-list-item-test.gjs
@@ -34,7 +34,7 @@ module('Integration | Component | session/objective-list-item', function (hooks)
       </template>,
     );
     assert.notOk(component.hasRemoveConfirmation);
-    assert.strictEqual(component.description.text, 'session objective 0');
+    assert.strictEqual(component.description.fadeText.displayText.text, 'session objective 0');
     assert.strictEqual(component.parents.text, 'Add New');
     assert.strictEqual(component.meshDescriptors.text, 'Add New');
     assert.ok(component.hasTrashCan);
@@ -63,11 +63,11 @@ module('Integration | Component | session/objective-list-item', function (hooks)
       </template>,
     );
     const newDescription = 'Pluto Visits Earth';
-    assert.strictEqual(component.description.text, 'session objective 0');
+    assert.strictEqual(component.description.fadeText.displayText.text, 'session objective 0');
     await component.description.openEditor();
     await component.description.edit(newDescription);
     await component.description.save();
-    assert.strictEqual(component.description.text, newDescription);
+    assert.strictEqual(component.description.fadeText.displayText.text, newDescription);
   });
 
   test('can manage parents', async function (assert) {

--- a/packages/test-app/tests/integration/components/session/objective-list-test.gjs
+++ b/packages/test-app/tests/integration/components/session/objective-list-test.gjs
@@ -43,7 +43,10 @@ module('Integration | Component | session/objective-list', function (hooks) {
     assert.strictEqual(component.headers[4].text, 'Actions');
 
     assert.strictEqual(component.objectives.length, 2);
-    assert.strictEqual(component.objectives[0].description.text, 'Objective B');
+    assert.strictEqual(
+      component.objectives[0].description.fadeText.displayText.text,
+      'Objective B',
+    );
     assert.strictEqual(
       component.objectives[0].selectedTerms.list[0].title,
       'Vocabulary 1 (school 0)',
@@ -52,7 +55,10 @@ module('Integration | Component | session/objective-list', function (hooks) {
       component.objectives[0].selectedTerms.list[0].terms[0].name,
       'term 1 (inactive)',
     );
-    assert.strictEqual(component.objectives[1].description.text, 'Objective A');
+    assert.strictEqual(
+      component.objectives[1].description.fadeText.displayText.text,
+      'Objective A',
+    );
     assert.strictEqual(
       component.objectives[1].selectedTerms.list[0].title,
       'Vocabulary 1 (school 0)',

--- a/packages/test-app/tests/integration/components/session/objectives-test.gjs
+++ b/packages/test-app/tests/integration/components/session/objectives-test.gjs
@@ -37,21 +37,21 @@ module('Integration | Component | session/objectives', function (hooks) {
 
     assert.strictEqual(component.objectiveList.objectives.length, 3);
     assert.strictEqual(
-      component.objectiveList.objectives[0].description.text,
+      component.objectiveList.objectives[0].description.fadeText.displayText.text,
       'session objective 0',
     );
     assert.ok(component.objectiveList.objectives[0].parents.empty);
     assert.ok(component.objectiveList.objectives[0].meshDescriptors.empty);
 
     assert.strictEqual(
-      component.objectiveList.objectives[1].description.text,
+      component.objectiveList.objectives[1].description.fadeText.displayText.text,
       'session objective 1',
     );
     assert.ok(component.objectiveList.objectives[1].parents.empty);
     assert.ok(component.objectiveList.objectives[1].meshDescriptors.empty);
 
     assert.strictEqual(
-      component.objectiveList.objectives[2].description.text,
+      component.objectiveList.objectives[2].description.fadeText.displayText.text,
       'session objective 2',
     );
     assert.strictEqual(component.objectiveList.objectives[2].parents.list.length, 1);

--- a/packages/test-app/tests/integration/components/session/overview-test.gjs
+++ b/packages/test-app/tests/integration/components/session/overview-test.gjs
@@ -34,7 +34,7 @@ module('Integration | Component | session/overview', function (hooks) {
     const sessionModel = await this.owner.lookup('service:store').findRecord('session', session.id);
     this.set('session', sessionModel);
     await render(<template><Overview @session={{this.session}} @editable={{true}} /></template>);
-    assert.strictEqual(component.sessionDescription.value, 'Click to edit');
+    assert.strictEqual(component.sessionDescription.text, 'Click to edit');
     await component.sessionDescription.edit();
     assert.notOk(component.sessionDescription.hasError);
     assert.notOk(component.sessionDescription.savingIsDisabled);
@@ -61,7 +61,7 @@ module('Integration | Component | session/overview', function (hooks) {
     const sessionModel = await this.owner.lookup('service:store').findRecord('session', session.id);
     this.set('session', sessionModel);
     await render(<template><Overview @session={{this.session}} @editable={{true}} /></template>);
-    assert.strictEqual(component.instructionalNotes.value, 'Click to edit');
+    assert.strictEqual(component.instructionalNotes.text, 'Click to edit');
     await component.instructionalNotes.edit();
     assert.notOk(component.instructionalNotes.hasError);
     assert.notOk(component.instructionalNotes.savingIsDisabled);
@@ -91,8 +91,8 @@ module('Integration | Component | session/overview', function (hooks) {
     await render(<template><Overview @session={{this.session}} @editable={{true}} /></template>);
     assert.strictEqual(sessionModel.description, '');
     assert.strictEqual(sessionModel.instructionalNotes, '');
-    assert.strictEqual(component.sessionDescription.value, 'Click to edit');
-    assert.strictEqual(component.instructionalNotes.value, 'Click to edit');
+    assert.strictEqual(component.sessionDescription.text, 'Click to edit');
+    assert.strictEqual(component.instructionalNotes.text, 'Click to edit');
     await component.sessionDescription.edit();
     await component.sessionDescription.save();
 
@@ -103,7 +103,7 @@ module('Integration | Component | session/overview', function (hooks) {
     assert.strictEqual(sessionModel.instructionalNotes, null);
   });
 
-  test('can save descrription when notes is empty string', async function (assert) {
+  test('can save description when notes is empty string', async function (assert) {
     const session = this.server.create('session', {
       course: this.course,
       sessionType: this.sessionTypes[0],
@@ -117,8 +117,8 @@ module('Integration | Component | session/overview', function (hooks) {
     const sessionModel = await this.owner.lookup('service:store').findRecord('session', session.id);
     this.set('session', sessionModel);
     await render(<template><Overview @session={{this.session}} @editable={{true}} /></template>);
-    assert.strictEqual(component.sessionDescription.value, 'not empty');
-    assert.strictEqual(component.instructionalNotes.value, 'Click to edit');
+    assert.strictEqual(component.sessionDescription.fadeText.displayText.text, 'not empty');
+    assert.strictEqual(component.instructionalNotes.text, 'Click to edit');
     await component.sessionDescription.edit();
     await component.sessionDescription.set('still not empty');
     await component.sessionDescription.save();
@@ -140,8 +140,8 @@ module('Integration | Component | session/overview', function (hooks) {
     const sessionModel = await this.owner.lookup('service:store').findRecord('session', session.id);
     this.set('session', sessionModel);
     await render(<template><Overview @session={{this.session}} @editable={{true}} /></template>);
-    assert.strictEqual(component.sessionDescription.value, 'Click to edit');
-    assert.strictEqual(component.instructionalNotes.value, 'not empty');
+    assert.strictEqual(component.sessionDescription.text, 'Click to edit');
+    assert.strictEqual(component.instructionalNotes.fadeText.displayText.text, 'not empty');
     await component.instructionalNotes.edit();
     await component.instructionalNotes.set('still not empty');
     await component.instructionalNotes.save();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -486,6 +486,9 @@ importers:
       quill:
         specifier: ^2.0.3
         version: 2.0.3
+      sanitize-html:
+        specifier: ^2.17.0
+        version: 2.17.0
       striptags:
         specifier: '>= 3.2.0'
         version: 3.2.0
@@ -4929,6 +4932,10 @@ packages:
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
+  deepmerge@4.3.1:
+    resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
+    engines: {node: '>=0.10.0'}
+
   defaults@1.0.4:
     resolution: {integrity: sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==}
 
@@ -5027,6 +5034,9 @@ packages:
   dom-serializer@1.4.1:
     resolution: {integrity: sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==}
 
+  dom-serializer@2.0.0:
+    resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
+
   domain-browser@1.2.0:
     resolution: {integrity: sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==}
     engines: {node: '>=0.4', npm: '>=1.2'}
@@ -5053,6 +5063,10 @@ packages:
     resolution: {integrity: sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==}
     engines: {node: '>= 4'}
 
+  domhandler@5.0.3:
+    resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
+    engines: {node: '>= 4'}
+
   domutils@1.5.1:
     resolution: {integrity: sha512-gSu5Oi/I+3wDENBsOWBiRK1eoGxcywYSqg3rR960/+EfY0CF4EX1VPkgHOZ3WiS/Jg2DtliF6BhWcHlfpYUcGw==}
 
@@ -5061,6 +5075,9 @@ packages:
 
   domutils@2.8.0:
     resolution: {integrity: sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==}
+
+  domutils@3.2.2:
+    resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
 
   dot-case@3.0.4:
     resolution: {integrity: sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==}
@@ -6581,6 +6598,9 @@ packages:
   htmlparser2@5.0.1:
     resolution: {integrity: sha512-vKZZra6CSe9qsJzh0BjBGXo8dvzNsq/oGvsjfRdOrrryfeD9UOBEEQdeoqCRmKZchF5h2zOBMQ6YuQ0uRUmdbQ==}
 
+  htmlparser2@8.0.2:
+    resolution: {integrity: sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==}
+
   http-errors@1.6.3:
     resolution: {integrity: sha512-lks+lVC8dgGyh97jxvxeYTWQFvh4uw4yC12gVl63Cg30sjPX4wuGcdkICVXDAESr6OJGjqGA8Iz5mkeN6zlD7A==}
     engines: {node: '>= 0.6'}
@@ -7978,6 +7998,9 @@ packages:
     resolution: {integrity: sha512-1Y1A//QUXEZK7YKz+rD9WydcE1+EuPr6ZBgKecAB8tmoW6UFv0NREVJe1p+jRxtThkcbbKkfwIbWJe/IeE6m2Q==}
     engines: {node: '>=0.10.0'}
 
+  parse-srcset@1.0.2:
+    resolution: {integrity: sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q==}
+
   parse-static-imports@1.1.0:
     resolution: {integrity: sha512-HlxrZcISCblEV0lzXmAHheH/8qEkKgmqkdxyHTPbSqsTUV8GzqmN1L+SSti+VbNPfbBO3bYLPHDiUs2avbAdbA==}
 
@@ -8673,6 +8696,9 @@ packages:
     resolution: {integrity: sha512-9/0CYoRz0MKKf04OMCO3Qk3RQl1PAwWAhPSQSym4ULiLpTZnrY1JoZU0IEikHu8kdk2HvKT/VwQMq/xFZ8kh1Q==}
     engines: {node: 10.* || >= 12.*}
     hasBin: true
+
+  sanitize-html@2.17.0:
+    resolution: {integrity: sha512-dLAADUSS8rBwhaevT12yCezvioCA+bmUTPH/u57xKPT8d++voeYE6HeluA/bPbQ15TwDBG2ii+QZIEmYx8VdxA==}
 
   sass@1.93.2:
     resolution: {integrity: sha512-t+YPtOQHpGW1QWsh1CHQ5cPIr9lbbGZLZnbihP/D/qZj/yuV68m8qarcV17nvkOX81BCrvzAlq2klCQFZghyTg==}
@@ -15068,6 +15094,8 @@ snapshots:
 
   deep-is@0.1.4: {}
 
+  deepmerge@4.3.1: {}
+
   defaults@1.0.4:
     dependencies:
       clone: 1.0.4
@@ -15165,6 +15193,12 @@ snapshots:
       domhandler: 4.3.1
       entities: 2.2.0
 
+  dom-serializer@2.0.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      entities: 4.5.0
+
   domain-browser@1.2.0: {}
 
   domelementtype@1.3.1: {}
@@ -15187,6 +15221,10 @@ snapshots:
     dependencies:
       domelementtype: 2.3.0
 
+  domhandler@5.0.3:
+    dependencies:
+      domelementtype: 2.3.0
+
   domutils@1.5.1:
     dependencies:
       dom-serializer: 0.1.1
@@ -15202,6 +15240,12 @@ snapshots:
       dom-serializer: 1.4.1
       domelementtype: 2.3.0
       domhandler: 4.3.1
+
+  domutils@3.2.2:
+    dependencies:
+      dom-serializer: 2.0.0
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
 
   dot-case@3.0.4:
     dependencies:
@@ -17870,6 +17914,13 @@ snapshots:
       domutils: 2.8.0
       entities: 2.2.0
 
+  htmlparser2@8.0.2:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      entities: 4.5.0
+
   http-errors@1.6.3:
     dependencies:
       depd: 1.1.2
@@ -19354,6 +19405,8 @@ snapshots:
 
   parse-passwd@1.0.0: {}
 
+  parse-srcset@1.0.2: {}
+
   parse-static-imports@1.1.0: {}
 
   parse5@6.0.1: {}
@@ -20038,6 +20091,15 @@ snapshots:
       micromatch: 4.0.8
       minimist: 1.2.8
       walker: 1.0.8
+
+  sanitize-html@2.17.0:
+    dependencies:
+      deepmerge: 4.3.1
+      escape-string-regexp: 4.0.0
+      htmlparser2: 8.0.2
+      is-plain-object: 5.0.0
+      parse-srcset: 1.0.2
+      postcss: 8.5.6
 
   sass@1.93.2:
     dependencies:


### PR DESCRIPTION
partial counter-proposal to this PR.

this flips some aspects of this on its ear.

the main goal is to get away from nesting rich text - faded or not - inside of a button. this should allow us to throw all the client-side link replacement stuff out again.

i'm using a new component  - `EditableText` - here. Edit controls are now passed into the `FadedText`, and state management of edit-mode is handled by the parent component (so far implemented in `ProgramYear::ObjectiveListItem`.

with a dedicated component for in-place editing of multi-line text, this will allow us to drastically strip down what `EditableField` is attempting to do, which is currently way too much IMHO.

still work in progress.

<img width="1003" height="561" alt="image (2)" src="https://github.com/user-attachments/assets/679d932d-22b7-4d0e-b649-90ada7452fcc" />
<img width="883" height="473" alt="image (3)" src="https://github.com/user-attachments/assets/e1c60e54-67f0-484d-a6f8-c9d88ca07070" />

